### PR TITLE
Ensure objects are not referenced multiple times within a spec 

### DIFF
--- a/pgbedrock/core_configure.py
+++ b/pgbedrock/core_configure.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 import getpass
 import logging
 import os
@@ -23,6 +24,11 @@ HEADER = '-- SQL EXECUTED ({} MODE)'
 FILE_OPEN_ERROR_MSG = "Unable to open file '{}':\n{}"
 MISSING_ENVVAR_MSG = "Required environment variable not found:\n{}"
 VALIDATION_ERR_MSG = 'Spec error: role "{}", field "{}": {}'
+MULTIPLE_SCHEMA_OWNER_ERR_MSG = 'Spec error: schema "{}" owned by more than one role: {}'
+DUPLICATE_ROLE_DEFINITIONS_ERR_MSG = 'Spec error: role(s) defined more than once: {}'
+OBJECT_REF_READ_WRITE_ERR = ('Spec error: objects have been unnecessarily given both read and write privileges.'
+                             'pgbedrock automatically grants read access when write access is requested.\n\t{}'
+                             )
 SUCCESS_MSG = "\nNo changes needed. Congratulations! :)"
 
 SPEC_SCHEMA_YAML = """
@@ -89,7 +95,7 @@ def has_changes(statements):
     return False
 
 
-def load_spec(path):
+def render_template(path):
     """ Load a spec. There may be templated password variables, which we render using Jinja. """
     try:
         dir_path, filename = os.path.split(path)
@@ -97,11 +103,12 @@ def load_spec(path):
                                          undefined=jinja2.StrictUndefined)
         loaded = environment.get_template(filename)
         rendered = loaded.render(env=os.environ)
-        return yaml.load(rendered)
     except jinja2.exceptions.TemplateNotFound as err:
         common.fail(FILE_OPEN_ERROR_MSG.format(path, err))
     except jinja2.exceptions.UndefinedError as err:
         common.fail(MISSING_ENVVAR_MSG.format(err))
+    else:
+        return rendered
 
 
 def run_module_sql(module_sql, cursor, verbose):
@@ -131,22 +138,114 @@ def run_password_sql(cursor, all_password_sql_to_run):
         common.fail(msg=common.FAILED_QUERY_MSG.format(query, e))
 
 
-def verify_spec(spec):
-    """ Ensure keywords make sense, particularly because it's easy to use singulars
-    instead of plurals (e.g. 'table' instead of 'tables') """
-    assert isinstance(spec, dict)
+def verify_schema(spec):
+    """Checks spec for schema errors."""
+    error_messages = []
 
     schema = yaml.load(SPEC_SCHEMA_YAML)
     v = cerberus.Validator(schema)
-    error_messages = []
     for rolename, config in spec.items():
         if not config:
             continue
-
         v.validate(config)
         for field, err_msg in v.errors.items():
             error_messages.append(VALIDATION_ERR_MSG.format(rolename, field, err_msg[0]))
 
+    return error_messages
+
+
+def check_for_multi_schema_owners(spec):
+    """Checks spec for schema with multiple owners."""
+    error_messages = []
+
+    globally_owned_schemas = defaultdict(list)
+    for role, config in spec.items():
+        if not config:
+            continue
+        if config.get('has_personal_schema'):
+            # indicates a role has a personal schema with its same name
+            globally_owned_schemas[role].append(role)
+        if config.get('owns') and config['owns'].get('schemas'):
+            role_owned_schemas = config['owns']['schemas']
+            for schema in role_owned_schemas:
+                globally_owned_schemas[schema].append(role)
+    for schema, owners in globally_owned_schemas.items():
+        if len(owners) > 1:
+            owners_formatted = ", ".join(owners)
+            error_messages.append(MULTIPLE_SCHEMA_OWNER_ERR_MSG.format(schema, owners_formatted))
+
+    return error_messages
+
+
+def check_read_write_obj_references(spec):
+    """Verifies objects aren't defined in both read and write privileges sections."""
+    error_messages = []
+
+    multi_refs = defaultdict(dict)
+    for role, config in spec.items():
+        if config and config.get('privileges'):
+            for obj in config['privileges']:
+                try:
+                    reads = set(config['privileges'][obj]['read'])
+                    writes = set(config['privileges'][obj]['write'])
+                    duplicates = reads.intersection(writes)
+                    if duplicates:
+                        multi_refs[role][obj] = list(duplicates)
+                except KeyError:
+                    continue
+    if multi_refs:
+        multi_ref_strings = ["%s: %s" % (k, v) for k, v in multi_refs.items()]
+        multi_ref_err_string = "\n\t".join(multi_ref_strings)
+        error_messages.append(OBJECT_REF_READ_WRITE_ERR.format(multi_ref_err_string))
+
+    return error_messages
+
+
+def detect_multiple_role_definitions(rendered_spec_template):
+    """Checks spec for roles declared multiple times.
+
+    In a spec template, if a role is declared more than once there exists a risk that the re-declaration will
+    override the desired configuration. pgbedrock considers a config containing this risk to be invalid and
+    will throw an error.
+
+    To accomplish this, the yaml.loader.Loader object is used to convert spec template
+    into a document tree.  Then, the root object's child nodes (which are the roles) are checked for duplicates.
+
+    Outputs:
+        []string    The decision to return a list of strings was deliberate, despite
+                    the fact that the length of the list can at most be one. The reason for this
+                    is that the other spec verification functions
+                    (check_for_multi_schema_owners and check_read_write_obj_references, verify_schema)
+                    also return a list of strings.  This return signature consistency makes the code
+                    in the verify_spec function cleaner.
+    """
+    error_messages = []
+    loader = yaml.loader.Loader(rendered_spec_template)
+    document_tree = loader.get_single_node()
+    if document_tree is None:
+        return None
+
+    role_definitions = defaultdict(int)
+    for node in document_tree.value:
+        role_definitions[node[0].value] += 1
+    multi_defined_roles = [k for k, v in role_definitions.items() if v > 1]
+    if multi_defined_roles:
+        error_message = " ,".join(multi_defined_roles)
+        error_messages = [DUPLICATE_ROLE_DEFINITIONS_ERR_MSG.format(error_message)]
+
+    return error_messages
+
+
+def verify_spec(rendered_template, spec):
+    assert isinstance(spec, dict)
+
+    error_messages = []
+    error_messages += detect_multiple_role_definitions(rendered_template)
+    verification_functions = (verify_schema,
+                              check_for_multi_schema_owners,
+                              check_read_write_obj_references)
+    for fn in verification_functions:
+        error_messages += fn(spec)
     if error_messages:
         common.fail('\n'.join(error_messages))
 
@@ -203,11 +302,14 @@ def configure(spec, host, port, user, password, dbname, prompt, attributes, memb
     db_connection = common.get_db_connection(host, port, dbname, user, password)
     cursor = db_connection.cursor(cursor_factory=psycopg2.extras.DictCursor)
 
-    spec = load_spec(spec)
+
+    rendered_template = render_template(spec)
+    spec = yaml.load(rendered_template)
+    verify_spec(rendered_template, spec)
+
     sql_to_run = []
     password_changed = False  # Initialize this in case the attributes module isn't run
 
-    verify_spec(spec)
 
     if attributes:
         sql_to_run.append(create_divider('attributes'))


### PR DESCRIPTION
A few things I am wondering about: 

1. detect_multiple_role_definitions requires a template rather than dictionary like verify_spec method. I wasnt sure where was the best place to run detect_multiple_role_definitions, I added it to load_spec since we would essentially have to do the same thing if we were to keep the two separate

2. error string on objs referenced in read/write might be misleading.  if obj with the same name is referenced in read write for multiple sections ( schema / table / sequence ) the name will simply show up multiple times in the error string
Example:
```
    danil:
        can_login: true
        privileges:
            sequences:
                read:
                    - hoop
                write:
                    - hoop
            tables:
                read:
                    - hoop
                write:
                    - hoop
```
error string will be: danil: [hoop, hoop]

Should we add more info? 

Looking forward to hearing your feedback! 
