### PR TITLE
Add --role CLI, support generating prior to PostgreSQL 9.5

### DIFF
--- a/pgbedrock/attributes.py
+++ b/pgbedrock/attributes.py
@@ -56,6 +56,9 @@ PG_COLUMN_NAME = {
 # We also need a reverse lookup of PG_COLUMN_NAME
 COLUMN_NAME_TO_KEYWORD = {v: k for k, v in PG_COLUMN_NAME.items()}
 
+# Columns to ignore (Pre Postgres 9.5)
+IGNORE = ['rolcatupdate']
+
 
 def analyze_attributes(spec, cursor, verbose):
     logger.debug('Starting analyze_attributes()')

--- a/pgbedrock/cli.py
+++ b/pgbedrock/cli.py
@@ -21,13 +21,14 @@ def entrypoint():
 @click.option('-w', '--password', default="", help='database user password; (default: "")')
 @click.option('-d', '--dbname', default=USER, help='database to connect to (default: "{}")'.format(USER))
 @click.option('--prompt/--no-prompt', default=False, help='prompt the user to input a password (default: --no-prompt)')
+@click.option('--role', default="", help='do SET ROLE prior to configuration')
 @click.option('--attributes/--no-attributes', default=True, help='whether to configure role attributes (default: --attributes)')
 @click.option('--memberships/--no-memberships', default=True, help='whether to configure memberships (default: --membership)')
 @click.option('--ownerships/--no-ownerships', default=True, help='whether to configure object ownerships (default: --ownerships)')
 @click.option('--privileges/--no-privileges', default=True, help='whether to configure privileges (default: --privileges)')
 @click.option('--live/--check', default=False, help='whether to actually make changes ("live") or only show what would be changed ("check") (default: --check)')
 @click.option('--verbose/--no-verbose', default=False, help='whether to show debug-level logging messages while running (default: --no-verbose)')
-def configure(spec, host, port, user, password, dbname, prompt, attributes, memberships, ownerships,
+def configure(spec, host, port, user, password, dbname, prompt, role, attributes, memberships, ownerships,
               privileges, live, verbose):
     """
     Configure the role attributes, memberships, object ownerships, and/or privileges of a
@@ -41,7 +42,7 @@ def configure(spec, host, port, user, password, dbname, prompt, attributes, memb
     In addition, using --verbose will print to STDOUT all debug statements and all SQL queries
     issued by pgbedrock.
     """
-    core_configure.configure(spec, host, port, user, password, dbname, prompt, attributes,
+    core_configure.configure(spec, host, port, user, password, dbname, prompt, role, attributes,
                              memberships, ownerships, privileges, live, verbose)
 
 
@@ -52,13 +53,14 @@ def configure(spec, host, port, user, password, dbname, prompt, attributes, memb
 @click.option('-w', '--password', default="", help='database user password; (default: "")')
 @click.option('-d', '--dbname', default=USER, help='database to connect to (default: "{}")'.format(USER))
 @click.option('--prompt/--no-prompt', default=False, help='prompt the user to input a password (default: --no-prompt)')
+@click.option('--role', default="", help='do SET ROLE prior to configuration')
 @click.option('--verbose/--no-verbose', default=False, help='whether to show debug-level logging messages while running (default: --no-verbose)')
-def generate(host, port, user, password, dbname, prompt, verbose):
+def generate(host, port, user, password, dbname, prompt, role, verbose):
     """
     Generate a YAML spec that represents the roles, memberships, ownerships, and/or privileges of a
     database.
     """
-    core_generate.generate(host, port, user, password, dbname, prompt, verbose)
+    core_generate.generate(host, port, user, password, dbname, prompt, role, verbose)
 
 
 if __name__ == '__main__':

--- a/pgbedrock/core_configure.py
+++ b/pgbedrock/core_configure.py
@@ -250,7 +250,7 @@ def verify_spec(rendered_template, spec):
         common.fail('\n'.join(error_messages))
 
 
-def configure(spec, host, port, user, password, dbname, prompt, attributes, memberships,
+def configure(spec, host, port, user, password, dbname, prompt, role, attributes, memberships,
               ownerships, privileges, live, verbose):
     """
     Configure the role attributes, memberships, object ownerships, and/or privileges of a
@@ -275,6 +275,8 @@ def configure(spec, host, port, user, password, dbname, prompt, attributes, memb
         dbname - str; the database to connect to and configure
 
         prompt - bool; whether to prompt for a password
+
+        role - str; perform SET ROLE to this value prior to operation
 
         attributes - bool; whether to configure the role attributes for the specified
             database cluster
@@ -302,6 +304,8 @@ def configure(spec, host, port, user, password, dbname, prompt, attributes, memb
     db_connection = common.get_db_connection(host, port, dbname, user, password)
     cursor = db_connection.cursor(cursor_factory=psycopg2.extras.DictCursor)
 
+    if role:
+        cursor.execute('SET ROLE=%(role)s', {'role': role})
 
     rendered_template = render_template(spec)
     spec = yaml.load(rendered_template)


### PR DESCRIPTION
This PR adds two things:

1. Adds a --role CLI argument that will triggers pgbedrock to `SET ROLE` prior to performing any database operations.  This mirrors the argument in `pg_dump` and is used similar to a `su` or `sudo` type functionality. See [SET ROLE](https://www.postgresql.org/docs/current/static/sql-set-role.html)

2. Adds a new list called IGNORE in attributes that lists columns to ignore. Prior to 9.5 there was an attribute in `pg_authid` called `rolcatupdate`. While I only needed to ignore that one, I figured having a list of things to ignore would be a solid thing to do for future issues of a similar nature. In addition, I changed the dict references that could cause a `KeyError` if an unknown column was encountered to just return the column name.

I didn't see much opportunity to cleanly add test coverage for these options, but if coverage would help get the PR merged and a new version released with these additions, I'd be happy to provide it.

Thanks for an interesting tool!