### PR TITLE
block test suite on dockerized test db explicitly

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,9 +23,17 @@ NEW_USER = 'foobar'
 
 @pytest.fixture(scope='session')
 def db_config():
-    host = 'pgbedrock_postgres' if os.environ.get('WITHIN_DOCKER_FLAG') else 'localhost'
+    """
+    db config assumes you are using the postgres db provided by the docker
+    container either connecting to it through localhost if you're running the
+    test suite outside of docker, or through docker's network if you are running
+    the test suite from within docker
+    """
+    in_docker = os.environ.get('WITHIN_DOCKER_FLAG', False)
+    host = 'pgbedrock_postgres' if in_docker else 'localhost'
+    port = 5432 if in_docker else 54321
     yield {'host': host,
-           'port': 5432,
+           'port': port,
            'user': 'test_user',
            'password': 'test_password',
            'dbname': 'test_db'}

--- a/tests/wait_for_postgres.sh
+++ b/tests/wait_for_postgres.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+PG_ISREADY=/usr/lib/postgresql/9.6/bin/pg_isready
+ISREADY="$PG_ISREADY --host=$POSTGRES_HOST"
+$ISREADY
+while [[ $? -ne 0 ]]; do
+    sleep 1
+    echo "waiting on Postgres"
+    $ISREADY
+done


### PR DESCRIPTION
If you have a Postgres server running on 5432, docker for mac will silently fail to setup the port forwarding and the original server will intercept traffic intended for the test db that runs in a docker container.

By removing the port from getting forwarded and making the "wait_for_postgres" target connect to the test db through docker's networking, processes on the host will no longer interfere with the test suite.

I removed port forwarding in general from the setup of the test db which I'm not sure is ideal, but I'd like to work through some usability issues that this brings up if anyone can see problems with it.