### PR TITLE
Refactor obj owner queries

### DIFF
--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -490,9 +490,10 @@ class DatabaseContext(object):
         return all_objects_and_owners.get(schema, [])
 
     def is_schema_empty(self, schema, object_kind):
+        """ Determine if the schema is empty with regard to the object kind specified """
         all_objects_and_owners = self.get_all_nonschema_objects_and_owners()
-        for objkind, objname, _, _ in all_objects_and_owners.get(schema, []):
-            if objkind == object_kind:
+        for obj in all_objects_and_owners.get(schema, []):
+            if obj.kind == object_kind:
                 return False
 
         return True

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -160,7 +160,7 @@ Q_GET_ALL_NONSCHEMA_OBJECTS_AND_OWNERS = """
     ;
     """
 
-Q_GET_ALL_OBJECT_OWNERS = """
+Q_GET_ALL_OBJECT_ATTRIBUTES = """
     WITH relkind_mapping (objkey, objkind) AS (
         VALUES ('r', 'tables'),
                ('v', 'tables'),
@@ -257,7 +257,7 @@ class DatabaseContext(object):
     cacheables = {
         'get_all_current_defaults',
         'get_all_current_nondefaults',
-        'get_all_object_owners',
+        'get_all_object_attributes',
         'get_all_role_attributes',
         'get_all_memberships',
         'get_all_nonschema_objects_and_owners',
@@ -433,7 +433,7 @@ class DatabaseContext(object):
         role_attributes = self.get_role_attributes(rolename)
         return role_attributes.get('rolsuper', False)
 
-    def get_all_object_owners(self):
+    def get_all_object_attributes(self):
         """ Return a dict of the form:
             {objkindA: {
                 'schemaA': {
@@ -459,7 +459,7 @@ class DatabaseContext(object):
         """
         OwnerRow = namedtuple('OwnerRow',
                               ['objkind', 'schema', 'objname', 'owner', 'is_dependent'])
-        common.run_query(self.cursor, self.verbose, Q_GET_ALL_OBJECT_OWNERS)
+        common.run_query(self.cursor, self.verbose, Q_GET_ALL_OBJECT_ATTRIBUTES)
         all_object_owners = defaultdict(dict)
         for i in self.cursor.fetchall():
             row = OwnerRow(*i)
@@ -479,7 +479,7 @@ class DatabaseContext(object):
 
     def get_all_schemas_and_owners(self):
         """ Return a dict of {schema_name: schema_owner} """
-        all_object_owners = self.get_all_object_owners()
+        all_object_owners = self.get_all_object_attributes()
         schemas_subdict = all_object_owners.get('schemas', {})
         schema_owners = {k: v[k]['owner'] for k, v in schemas_subdict.items()}
         return schema_owners
@@ -514,7 +514,7 @@ class DatabaseContext(object):
         return schema_objects
 
     def get_schema_objects(self, schema):
-        # all_object_owners = self.get_all_object_owners()
+        # all_object_owners = self.get_all_object_attributes()
         all_objects_and_owners = self.get_all_nonschema_objects_and_owners()
         return all_objects_and_owners.get(schema, [])
 

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -133,7 +133,7 @@ Q_GET_ALL_NONSCHEMA_OBJECTS_AND_OWNERS = """
         nsp.nspname AS schema,
         map.objkind,
         nsp.nspname || '."' || c.relname || '"' AS objname,
-        r.rolname AS owner,
+        auth.rolname AS owner,
         -- Auto-dependency means that a sequence is linked to a table. Ownership of
         -- that sequence automatically derives from the table's ownership
         COUNT(deps.refobjid) > 0 AS has_auto_dependency
@@ -143,8 +143,8 @@ Q_GET_ALL_NONSCHEMA_OBJECTS_AND_OWNERS = """
             ON c.relnamespace = nsp.oid
         JOIN relkind_mapping map
             ON c.relkind = map.objkey
-        JOIN pg_roles r
-            ON c.relowner = r.OID
+        JOIN pg_authid auth
+            ON c.relowner = auth.OID
         LEFT JOIN pg_depend deps
             ON deps.objid = c.oid
             AND deps.classid = 'pg_class'::REGCLASS

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -1,4 +1,3 @@
-import collections
 import logging
 
 from collections import defaultdict, namedtuple
@@ -208,7 +207,7 @@ PRIVILEGE_MAP = {
          },
 }
 
-ObjectInfo = collections.namedtuple('ObjectInfo', ['kind', 'name', 'owner', 'is_dependent'])
+ObjectInfo = namedtuple('ObjectInfo', ['kind', 'name', 'owner', 'is_dependent'])
 
 
 class DatabaseContext(object):
@@ -474,7 +473,7 @@ class DatabaseContext(object):
         """ For all objkinds other than schemas return a dict of the form
                 {schema_name: [(objkind, objname, objowner, is_dependent), ...]}
         """
-        schema_objects = collections.defaultdict(list)
+        schema_objects = defaultdict(list)
         for row in self.fetch_all_object_attributes():
             if row.kind != 'schemas':
                 objinfo = ObjectInfo(row.kind, row.name, row.owner, row.is_dependent)

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -150,8 +150,6 @@ Q_GET_ALL_NONSCHEMA_OBJECTS_AND_OWNERS = """
             AND deps.classid = 'pg_class'::REGCLASS
             AND deps.refclassid = 'pg_class'::REGCLASS
             AND deps.deptype = 'a'
-        LEFT JOIN pg_class owning_obj
-            ON owning_obj.oid = deps.refobjid
     WHERE
         nsp.nspname NOT LIKE 'pg\_t%'
     GROUP BY

--- a/pgbedrock/privileges.py
+++ b/pgbedrock/privileges.py
@@ -266,7 +266,7 @@ class PrivilegeAnalyzer(object):
         objkind = objkind or self.object_kind
         schema = item.split('.', 1)[0]
         object_owners = self.all_object_owners.get(objkind, dict()).get(schema, dict())
-        owner = object_owners.get(item, None)
+        owner = object_owners.get(item, dict()).get('owner', None)
         if owner:
             return owner
         else:
@@ -278,7 +278,7 @@ class PrivilegeAnalyzer(object):
         """ Get all objects of kind self.object_kind which are in the given schema and not owned by
         self.rolename """
         object_owners = self.all_object_owners.get(self.object_kind, dict()).get(schema, dict())
-        return {objname for objname, owner in object_owners.items() if owner != self.rolename}
+        return {name for name, attr in object_owners.items() if attr['owner'] != self.rolename}
 
     def get_schema_owner(self, schema):
         return self.get_object_owner(schema, objkind='schemas')

--- a/pgbedrock/privileges.py
+++ b/pgbedrock/privileges.py
@@ -210,7 +210,7 @@ class PrivilegeAnalyzer(object):
 
         self.current_defaults = dbcontext.get_role_current_defaults(rolename, object_kind, access)
         self.current_nondefaults = dbcontext.get_role_current_nondefaults(rolename, object_kind, access)
-        self.all_object_owners = dbcontext.get_all_object_owners()
+        self.all_object_attrs = dbcontext.get_all_object_attributes()
 
     def analyze(self):
         self.identify_desired_objects()
@@ -265,7 +265,7 @@ class PrivilegeAnalyzer(object):
     def get_object_owner(self, item, objkind=None):
         objkind = objkind or self.object_kind
         schema = item.split('.', 1)[0]
-        object_owners = self.all_object_owners.get(objkind, dict()).get(schema, dict())
+        object_owners = self.all_object_attrs.get(objkind, dict()).get(schema, dict())
         owner = object_owners.get(item, dict()).get('owner', None)
         if owner:
             return owner
@@ -277,7 +277,7 @@ class PrivilegeAnalyzer(object):
     def get_schema_objects(self, schema):
         """ Get all objects of kind self.object_kind which are in the given schema and not owned by
         self.rolename """
-        object_owners = self.all_object_owners.get(self.object_kind, dict()).get(schema, dict())
+        object_owners = self.all_object_attrs.get(self.object_kind, dict()).get(schema, dict())
         return {name for name, attr in object_owners.items() if attr['owner'] != self.rolename}
 
     def get_schema_owner(self, schema):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -466,3 +466,11 @@ def test_get_schema_objects_no_entry():
     }
     actual = dbcontext.get_schema_objects('key_not_in_response')
     assert actual == []
+
+
+def test_fetch_all_object_attributes(cursor):
+    dbcontext = context.DatabaseContext(cursor, verbose=True)
+    fetched = dbcontext.fetch_all_object_attributes()
+    assert isinstance(fetched, list)
+    assert len(fetched) > 0
+    assert isinstance(fetched[0], tuple)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -243,24 +243,24 @@ def test_get_all_object_owners(cursor):
     expected = {
         'tables': {
             SCHEMAS[0]: {
-                quoted_object(SCHEMAS[0], TABLES[0]): ROLES[1],
-                quoted_object(SCHEMAS[0], TABLES[1]): ROLES[1],
-                quoted_object(SCHEMAS[0], TABLES[2]): ROLES[3],
+                quoted_object(SCHEMAS[0], TABLES[0]): {'owner': ROLES[1], 'is_dependent': False},
+                quoted_object(SCHEMAS[0], TABLES[1]): {'owner': ROLES[1], 'is_dependent': False},
+                quoted_object(SCHEMAS[0], TABLES[2]): {'owner': ROLES[3], 'is_dependent': False},
             }
         },
         'sequences': {
             SCHEMAS[0]: {
-                quoted_object(SCHEMAS[0], SEQUENCES[0]): ROLES[1],
-                quoted_object(SCHEMAS[0], SEQUENCES[1]): ROLES[2],
-                quoted_object(SCHEMAS[0], SEQUENCES[2]): ROLES[2],
+                quoted_object(SCHEMAS[0], SEQUENCES[0]): {'owner': ROLES[1], 'is_dependent': False},
+                quoted_object(SCHEMAS[0], SEQUENCES[1]): {'owner': ROLES[2], 'is_dependent': False},
+                quoted_object(SCHEMAS[0], SEQUENCES[2]): {'owner': ROLES[2], 'is_dependent': False},
             }
         },
         'schemas': {
             SCHEMAS[0]: {
-                SCHEMAS[0]: ROLES[0],
+                SCHEMAS[0]: {'owner': ROLES[0], 'is_dependent': False},
             },
             'public': {
-                'public': 'postgres',
+                'public': {'owner': 'postgres', 'is_dependent': False},
             }
         }
     }

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -468,9 +468,9 @@ def test_get_schema_objects_no_entry():
     assert actual == []
 
 
-def test_fetch_all_object_attributes(cursor):
+def test_get_all_raw_object_attributes(cursor):
     dbcontext = context.DatabaseContext(cursor, verbose=True)
-    fetched = dbcontext.fetch_all_object_attributes()
-    assert isinstance(fetched, list)
-    assert len(fetched) > 0
-    assert isinstance(fetched[0], tuple)
+    raw_results = dbcontext.get_all_raw_object_attributes()
+    assert isinstance(raw_results, list)
+    assert len(raw_results) > 0
+    assert isinstance(raw_results[0], tuple)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -238,7 +238,7 @@ def test_get_role_objects_with_access(access, expected):
         # Role3 owns 1 table (2) and 0 sequences
         Q_CREATE_TABLE.format(ROLES[3], SCHEMAS[0], TABLES[2]),
     ])
-def test_get_all_object_owners(cursor):
+def test_get_all_object_attributes(cursor):
     dbcontext = context.DatabaseContext(cursor, verbose=True)
     expected = {
         'tables': {
@@ -265,7 +265,7 @@ def test_get_all_object_owners(cursor):
         }
     }
 
-    actual = dbcontext.get_all_object_owners()
+    actual = dbcontext.get_all_object_attributes()
 
     # We do this to avoid having to look at / filter out entries from
     # information_schema or pg_catalog
@@ -276,7 +276,7 @@ def test_get_all_object_owners(cursor):
 
     # Make sure that this data is cached for future use
     cursor.close()
-    actual_again = dbcontext.get_all_object_owners()
+    actual_again = dbcontext.get_all_object_attributes()
     assert actual_again == actual
 
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -474,3 +474,8 @@ def test_get_all_raw_object_attributes(cursor):
     assert isinstance(raw_results, list)
     assert len(raw_results) > 0
     assert isinstance(raw_results[0], tuple)
+
+    # Make sure that this data is cached for future use
+    cursor.close()
+    raw_results_again = dbcontext.get_all_raw_object_attributes()
+    assert raw_results_again == raw_results

--- a/tests/test_privileges.py
+++ b/tests/test_privileges.py
@@ -247,7 +247,7 @@ def test_init_default_acl_possible(object_kind, mockdbcontext):
 def test_get_schema_objects_tables(mockdbcontext):
     objattributes = {'owner': ROLES[0], 'is_dependent': False}
     all_attributes = {quoted_object(SCHEMAS[0], t): objattributes for t in TABLES}
-    mockdbcontext.get_all_object_owners = lambda: {
+    mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             SCHEMAS[0]: all_attributes
         }
@@ -268,7 +268,7 @@ def test_get_schema_objects_sequences(mockdbcontext):
     we want to ensure we have coverage over more than just tables """
     objattributes = {'owner': ROLES[0], 'is_dependent': False}
     all_attributes = {quoted_object(SCHEMAS[0], seq): objattributes for seq in SEQUENCES}
-    mockdbcontext.get_all_object_owners = lambda: {
+    mockdbcontext.get_all_object_attributes = lambda: {
         'sequences': {
             SCHEMAS[0]: all_attributes
         }
@@ -289,7 +289,7 @@ def test_get_schema_objects_sequences(mockdbcontext):
     ('tables', quoted_object(SCHEMAS[0], TABLES[1]), ROLES[2]),
 ])
 def test_get_object_owner(mockdbcontext, object_kind, item, expected):
-    mockdbcontext.get_all_object_owners = lambda: {
+    mockdbcontext.get_all_object_attributes = lambda: {
         'schemas': {
             SCHEMAS[0]: {
                 SCHEMAS[0]: {'owner': ROLES[0], 'is_dependent': False},
@@ -315,7 +315,7 @@ def test_get_object_owner(mockdbcontext, object_kind, item, expected):
 def test_get_object_owner_nonexistent_object(capsys, mockdbcontext):
     object_kind = 'tables'
     item = 'foo.bar'
-    mockdbcontext.get_all_object_owners = lambda: {}
+    mockdbcontext.get_all_object_attributes = lambda: {}
     privconf = privs.PrivilegeAnalyzer(rolename=ROLES[0], access=DUMMY, object_kind=object_kind,
                                        desired_items=DUMMY, schema_writers=DUMMY,
                                        personal_schemas=DUMMY, dbcontext=mockdbcontext)
@@ -328,7 +328,7 @@ def test_get_object_owner_nonexistent_object(capsys, mockdbcontext):
 
 
 def test_get_schema_owner(mockdbcontext):
-    mockdbcontext.get_all_object_owners = lambda: {
+    mockdbcontext.get_all_object_attributes = lambda: {
         'schemas': {
             SCHEMAS[0]: {
                 SCHEMAS[0]: {'owner': ROLES[1], 'is_dependent': False},
@@ -380,7 +380,7 @@ def test_identify_desired_objects(rolename, mockdbcontext):
     # Using sequence-write because it has 2 types of privileges (i.e. >1 but not a ton)
     object_kind = 'sequences'
     access = 'write'
-    mockdbcontext.get_all_object_owners = lambda: {
+    mockdbcontext.get_all_object_attributes = lambda: {
         'sequences': {
             SCHEMAS[0]: {
                 quoted_object(SCHEMAS[0], SEQUENCES[0]): {'owner': ROLES[1], 'is_dependent': False},
@@ -443,7 +443,7 @@ def test_identify_desired_objects(rolename, mockdbcontext):
 def test_identify_desired_objects_personal_schemas_object_kind_is_schema(mockdbcontext):
     """ Make sure that if we desire 'personal_schemas' and the object_kind is a schema
     that the personal schemas do show up """
-    mockdbcontext.get_all_object_owners = lambda: {
+    mockdbcontext.get_all_object_attributes = lambda: {
         'schemas': {
             SCHEMAS[0]: {SCHEMAS[0]: {'owner': ROLES[0]}, 'is_dependent': False},
             SCHEMAS[1]: {SCHEMAS[1]: {'owner': ROLES[0]}, 'is_dependent': False},
@@ -469,7 +469,7 @@ def test_identify_desired_objects_personal_schemas_object_kind_is_not_schema(moc
     """ Make sure that if we desire 'personal_schemas.*' and the object_kind is something
     other than 'schema' that items in personal schemas show up in the the desired_nondefaults and
     the personal schemas show up in the desired_defaults """
-    mockdbcontext.get_all_object_owners = lambda: {
+    mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             SCHEMAS[0]: {
                 quoted_object(SCHEMAS[0], TABLES[0]): {'owner': ROLES[1], 'is_dependent': False},
@@ -601,7 +601,7 @@ def test_analyze_defaults(mockdbcontext):
         (ROLES[3], SCHEMAS[0], 'SELECT'),
     ])
     mockdbcontext.get_role_current_nondefaults = lambda x, y, z: set()
-    mockdbcontext.get_all_object_owners = lambda: {
+    mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             SCHEMAS[0]: {
                 quoted_object(SCHEMAS[0], TABLES[0]): {'owner': ROLES[2], 'is_dependent': False},
@@ -653,7 +653,7 @@ def test_analyze_nondefaults(mockdbcontext):
         (quoted_object(SCHEMAS[0], TABLES[1]), 'SELECT'),
         (quoted_object(SCHEMAS[1], TABLES[3]), 'SELECT'),
     ])
-    mockdbcontext.get_all_object_owners = lambda: {
+    mockdbcontext.get_all_object_attributes = lambda: {
         'schemas': {
             SCHEMAS[0]: {SCHEMAS[0]: {'owner': ROLES[1], 'is_dependent': False}},
             SCHEMAS[1]: {SCHEMAS[1]: {'owner': ROLES[1], 'is_dependent': False}},

--- a/tests/test_privileges.py
+++ b/tests/test_privileges.py
@@ -245,10 +245,11 @@ def test_init_default_acl_possible(object_kind, mockdbcontext):
 
 
 def test_get_schema_objects_tables(mockdbcontext):
-    ownership = {quoted_object(SCHEMAS[0], t): ROLES[0] for t in TABLES}
+    objattributes = {'owner': ROLES[0], 'is_dependent': False}
+    all_attributes = {quoted_object(SCHEMAS[0], t): objattributes for t in TABLES}
     mockdbcontext.get_all_object_owners = lambda: {
         'tables': {
-            SCHEMAS[0]: ownership
+            SCHEMAS[0]: all_attributes
         }
     }
 
@@ -265,10 +266,11 @@ def test_get_schema_objects_tables(mockdbcontext):
 def test_get_schema_objects_sequences(mockdbcontext):
     """ While this test is almost identical to test_get_schema_objects_tables(), it's here because
     we want to ensure we have coverage over more than just tables """
-    ownership = {quoted_object(SCHEMAS[0], seq): ROLES[0] for seq in SEQUENCES}
+    objattributes = {'owner': ROLES[0], 'is_dependent': False}
+    all_attributes = {quoted_object(SCHEMAS[0], seq): objattributes for seq in SEQUENCES}
     mockdbcontext.get_all_object_owners = lambda: {
         'sequences': {
-            SCHEMAS[0]: ownership
+            SCHEMAS[0]: all_attributes
         }
     }
 
@@ -290,15 +292,15 @@ def test_get_object_owner(mockdbcontext, object_kind, item, expected):
     mockdbcontext.get_all_object_owners = lambda: {
         'schemas': {
             SCHEMAS[0]: {
-                SCHEMAS[0]: ROLES[0]
+                SCHEMAS[0]: {'owner': ROLES[0], 'is_dependent': False},
             },
         }, 'sequences': {
             SCHEMAS[0]: {
-                quoted_object(SCHEMAS[0], SEQUENCES[0]): ROLES[1]
+                quoted_object(SCHEMAS[0], SEQUENCES[0]): {'owner': ROLES[1], 'is_dependent': False},
             },
         }, 'tables': {
             SCHEMAS[0]: {
-                quoted_object(SCHEMAS[0], TABLES[1]): ROLES[2]
+                quoted_object(SCHEMAS[0], TABLES[1]): {'owner': ROLES[2], 'is_dependent': False},
             },
         },
     }
@@ -329,7 +331,7 @@ def test_get_schema_owner(mockdbcontext):
     mockdbcontext.get_all_object_owners = lambda: {
         'schemas': {
             SCHEMAS[0]: {
-                SCHEMAS[0]: ROLES[1]
+                SCHEMAS[0]: {'owner': ROLES[1], 'is_dependent': False},
             },
         },
     }
@@ -381,17 +383,17 @@ def test_identify_desired_objects(rolename, mockdbcontext):
     mockdbcontext.get_all_object_owners = lambda: {
         'sequences': {
             SCHEMAS[0]: {
-                quoted_object(SCHEMAS[0], SEQUENCES[0]): ROLES[1],
-                quoted_object(SCHEMAS[0], SEQUENCES[1]): ROLES[2],
-                quoted_object(SCHEMAS[0], SEQUENCES[2]): ROLES[2],
+                quoted_object(SCHEMAS[0], SEQUENCES[0]): {'owner': ROLES[1], 'is_dependent': False},
+                quoted_object(SCHEMAS[0], SEQUENCES[1]): {'owner': ROLES[2], 'is_dependent': False},
+                quoted_object(SCHEMAS[0], SEQUENCES[2]): {'owner': ROLES[2], 'is_dependent': False},
             }, SCHEMAS[1]: {
-                quoted_object(SCHEMAS[1], SEQUENCES[0]): ROLES[2],
-                quoted_object(SCHEMAS[1], SEQUENCES[1]): ROLES[1],
+                quoted_object(SCHEMAS[1], SEQUENCES[0]): {'owner': ROLES[2], 'is_dependent': False},
+                quoted_object(SCHEMAS[1], SEQUENCES[1]): {'owner': ROLES[1], 'is_dependent': False},
             },
         },
         'schemas': {
-            SCHEMAS[0]: {SCHEMAS[0]: ROLES[0]},
-            SCHEMAS[1]: {SCHEMAS[1]: ROLES[0]},
+            SCHEMAS[0]: {SCHEMAS[0]: {'owner': ROLES[0]}, 'is_dependent': False},
+            SCHEMAS[1]: {SCHEMAS[1]: {'owner': ROLES[0]}, 'is_dependent': False},
         },
     }
 
@@ -443,8 +445,8 @@ def test_identify_desired_objects_personal_schemas_object_kind_is_schema(mockdbc
     that the personal schemas do show up """
     mockdbcontext.get_all_object_owners = lambda: {
         'schemas': {
-            SCHEMAS[0]: {SCHEMAS[0]: ROLES[0]},
-            SCHEMAS[1]: {SCHEMAS[1]: ROLES[0]},
+            SCHEMAS[0]: {SCHEMAS[0]: {'owner': ROLES[0]}, 'is_dependent': False},
+            SCHEMAS[1]: {SCHEMAS[1]: {'owner': ROLES[0]}, 'is_dependent': False},
         },
     }
     personal_schemas = ROLES[1:3]
@@ -470,20 +472,20 @@ def test_identify_desired_objects_personal_schemas_object_kind_is_not_schema(moc
     mockdbcontext.get_all_object_owners = lambda: {
         'tables': {
             SCHEMAS[0]: {
-                quoted_object(SCHEMAS[0], TABLES[0]): ROLES[1],
+                quoted_object(SCHEMAS[0], TABLES[0]): {'owner': ROLES[1], 'is_dependent': False},
             },
             ROLES[2]: {
-                quoted_object(ROLES[2], TABLES[2]): ROLES[2],
-                quoted_object(ROLES[2], TABLES[3]): ROLES[2],
+                quoted_object(ROLES[2], TABLES[2]): {'owner': ROLES[2], 'is_dependent': False},
+                quoted_object(ROLES[2], TABLES[3]): {'owner': ROLES[2], 'is_dependent': False},
             },
             ROLES[3]: {
-                quoted_object(ROLES[3], TABLES[4]): ROLES[3],
-                quoted_object(ROLES[3], TABLES[5]): ROLES[3],
+                quoted_object(ROLES[3], TABLES[4]): {'owner': ROLES[3], 'is_dependent': False},
+                quoted_object(ROLES[3], TABLES[5]): {'owner': ROLES[3], 'is_dependent': False},
             },
         }, 'schemas': {
-            SCHEMAS[0]: {SCHEMAS[0]: ROLES[1]},
-            ROLES[2]: {ROLES[2]: ROLES[2]},
-            ROLES[3]: {ROLES[3]: ROLES[3]},
+            SCHEMAS[0]: {SCHEMAS[0]: {'owner': ROLES[1]}, 'is_dependent': False},
+            ROLES[2]: {ROLES[2]: {'owner': ROLES[2]}, 'is_dependent': False},
+            ROLES[3]: {ROLES[3]: {'owner': ROLES[3]}, 'is_dependent': False},
         },
     }
     personal_schemas = ROLES[2:4]
@@ -602,12 +604,12 @@ def test_analyze_defaults(mockdbcontext):
     mockdbcontext.get_all_object_owners = lambda: {
         'tables': {
             SCHEMAS[0]: {
-                quoted_object(SCHEMAS[0], TABLES[0]): ROLES[2]
+                quoted_object(SCHEMAS[0], TABLES[0]): {'owner': ROLES[2], 'is_dependent': False},
             },
         },
         'schemas': {
             SCHEMAS[0]: {
-                SCHEMAS[0]: ROLES[1]
+                SCHEMAS[0]: {'owner': ROLES[1], 'is_dependent': False},
             },
         },
     }
@@ -653,17 +655,17 @@ def test_analyze_nondefaults(mockdbcontext):
     ])
     mockdbcontext.get_all_object_owners = lambda: {
         'schemas': {
-            SCHEMAS[0]: {SCHEMAS[0]: ROLES[1]},
-            SCHEMAS[1]: {SCHEMAS[1]: ROLES[1]},
+            SCHEMAS[0]: {SCHEMAS[0]: {'owner': ROLES[1], 'is_dependent': False}},
+            SCHEMAS[1]: {SCHEMAS[1]: {'owner': ROLES[1], 'is_dependent': False}},
         },
         'tables': {
             SCHEMAS[0]: {
-                quoted_object(SCHEMAS[0], TABLES[0]): ROLES[2],
-                quoted_object(SCHEMAS[0], TABLES[1]): ROLES[3],
+                quoted_object(SCHEMAS[0], TABLES[0]): {'owner': ROLES[2], 'is_dependent': False},
+                quoted_object(SCHEMAS[0], TABLES[1]): {'owner': ROLES[3], 'is_dependent': False},
             },
             SCHEMAS[1]: {
-                quoted_object(SCHEMAS[1], TABLES[2]): ROLES[2],
-                quoted_object(SCHEMAS[1], TABLES[3]): ROLES[3],
+                quoted_object(SCHEMAS[1], TABLES[2]): {'owner': ROLES[2], 'is_dependent': False},
+                quoted_object(SCHEMAS[1], TABLES[3]): {'owner': ROLES[3], 'is_dependent': False},
             },
         }
     }


### PR DESCRIPTION
This PR is in preparation for supporting table and sequence ownership (Issue #4).

It combines three queries that are almost identical: 
* Q_GET_ALL_NONSCHEMA_OBJECTS_AND_OWNERS
* Q_GET_ALL_OBJECT_OWNERS
* Q_GET_ALL_SCHEMAS_AND_OWNERS

In addition to combining these queries, the downstream methods that use them had to be rewritten to facilitate using a single source.