### PR TITLE
config the port from outside the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ python:
   - "2.7"
   - "3.6"
 services:
-    - postgresql
+  - postgresql
+env:
+  - POSTGRES_PORT=5432
 install:
   - pip install -e . -r requirements-dev.txt
 

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ test27:
 	@docker run \
         --rm \
         -e WITHIN_DOCKER_FLAG=true \
+        -e POSTGRES_PORT=5432 \
         -v $(shell pwd):/opt \
         --net=$(COMPOSED_NETWORK) \
         tester27
@@ -102,6 +103,7 @@ test36:
 	@docker run \
         --rm \
         -e WITHIN_DOCKER_FLAG=true \
+        -e POSTGRES_PORT=5432 \
         -v $(shell pwd):/opt \
         --net=$(COMPOSED_NETWORK) \
         tester36

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ def db_config():
     """
     in_docker = os.environ.get('WITHIN_DOCKER_FLAG', False)
     host = 'pgbedrock_postgres' if in_docker else 'localhost'
-    port = 5432 if in_docker else 54321
+    port = int(os.environ.get('POSTGRES_PORT', '54321'))
     yield {'host': host,
            'port': port,
            'user': 'test_user',


### PR DESCRIPTION
when i implemented travis but did other things to the build, those two PR's were interacting in a weird way.

This hopefully brings things under a more reasonable alignment between our builds.