### PR TITLE
Sort generated spec output

### DIFF
--- a/pgbedrock/core_generate.py
+++ b/pgbedrock/core_generate.py
@@ -360,6 +360,25 @@ def remove_default_attributes(attributes):
     return nondefaults
 
 
+def sort_sublists(data):
+    """
+    Ensure that any lists within the provided (possibly nested) structure are sorted. This is
+    done because PyYAML will sort the keys in a mapping but preserves the order of lists.
+
+    While it would be possible to ensure everything is sorted upstream, i.e. when it is added to
+    each sublist, putting this functionality into a function becomes cleaner for testing and a
+    better separation of concerns
+    """
+    if isinstance(data, dict):
+        for key, values in data.items():
+            sorted_values = sort_sublists(values)
+            data[key] = sorted_values
+    elif isinstance(data, list):
+        data = sorted(data)
+
+    return data
+
+
 def generate(host, port, user, password, dbname, prompt, verbose):
     """
     Generate a YAML spec that represents the role attributes, memberships, object ownerships,
@@ -394,4 +413,5 @@ def generate(host, port, user, password, dbname, prompt, verbose):
         password = getpass.getpass()
 
     spec = create_spec(host, port, user, password, dbname, verbose)
-    output_spec(spec)
+    sorted_spec = sort_sublists(spec)
+    output_spec(sorted_spec)

--- a/tests/test_core_generate.py
+++ b/tests/test_core_generate.py
@@ -745,3 +745,14 @@ def test_output_spec(capsys):
     core_generate.output_spec(spec)
     out, err = capsys.readouterr()
     assert out == expected
+
+
+@pytest.mark.parametrize("input_, expected", [
+    ([3, 1, 5, 2], [1, 2, 3, 5]),
+    (8, 8),
+    ('some text', 'some text'),
+    ({'a': 3, 'b': 'foo', 'c': []}, {'a': 3, 'b': 'foo', 'c': []}),
+    ({'a': [0, 6, 1], 'b': {'c': [8, 3, 1]}}, {'a': [0, 1, 6], 'b': {'c': [1, 3, 8]}}),
+])
+def test_sort_sublists(input_, expected):
+    assert core_generate.sort_sublists(input_) == expected


### PR DESCRIPTION
pgbedrock generate currently outputs a spec with the keys in sorted
order. This is because PyYAML by default sorts the output of a mapping
(e.g. dict). However, the order of all items in a list is left
preserved. This makes sense, but ideally we would sort this output, for
two reasons:
1) It is easier for an end user to inspect their spec: they can look at
things alphabetically.
2) It is easier to compare specs, whether that's when we run `pgbedrock
generate` on a new version of the codebase and want to compare it to the
existing spec, or when a user for whatever reason generates a new spec
and wants to compare it to their existing one. By not having this in
sorted order, the specs look superficially different.

This commit adds a function that sorts all lists within a generated spec
before outputting that spec.