### PR TITLE
Extract spec inspection and loading into submodule

### DIFF
--- a/pgbedrock/core_configure.py
+++ b/pgbedrock/core_configure.py
@@ -1,13 +1,8 @@
-from collections import defaultdict
 import getpass
 import logging
-import os
 
 import click
-import cerberus
-import jinja2
 import psycopg2.extras
-import yaml
 
 from pgbedrock import LOG_FORMAT
 from pgbedrock import common
@@ -15,66 +10,14 @@ from pgbedrock.attributes import analyze_attributes
 from pgbedrock.memberships import analyze_memberships
 from pgbedrock.ownerships import analyze_schemas
 from pgbedrock.privileges import analyze_privileges
+from pgbedrock.spec_inspector import load_spec
 
 
 logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
 logger = logging.getLogger(__name__)
 
 HEADER = '-- SQL EXECUTED ({} MODE)'
-FILE_OPEN_ERROR_MSG = "Unable to open file '{}':\n{}"
-MISSING_ENVVAR_MSG = "Required environment variable not found:\n{}"
-VALIDATION_ERR_MSG = 'Spec error: role "{}", field "{}": {}'
-MULTIPLE_SCHEMA_OWNER_ERR_MSG = 'Spec error: schema "{}" owned by more than one role: {}'
-DUPLICATE_ROLE_DEFINITIONS_ERR_MSG = 'Spec error: role(s) defined more than once: {}'
-OBJECT_REF_READ_WRITE_ERR = ('Spec error: objects have been unnecessarily given both read and write privileges.'
-                             'pgbedrock automatically grants read access when write access is requested.\n\t{}'
-                             )
 SUCCESS_MSG = "\nNo changes needed. Congratulations! :)"
-
-SPEC_SCHEMA_YAML = """
-    can_login:
-        type: boolean
-    has_personal_schema:
-        type: boolean
-    is_superuser:
-        type: boolean
-    attributes:
-        type: list
-        schema:
-            type: string
-            forbidden:
-                - LOGIN
-                - NOLOGIN
-                - SUPERUSER
-                - NOSUPERUSER
-    member_of:
-        type: list
-        schema:
-            type: string
-    privileges:
-        type: dict
-        allowed:
-            - schemas
-            - sequences
-            - tables
-        valueschema:
-            type: dict
-            allowed:
-                - read
-                - write
-            valueschema:
-                type: list
-                schema:
-                    type: string
-    owns:
-        type: dict
-        allowed:
-            - schemas
-        valueschema:
-            type: list
-            schema:
-                type: string
-    """
 
 
 def create_divider(section):
@@ -93,22 +36,6 @@ def has_changes(statements):
         if not stmt.startswith('--') and not stmt.startswith('\n\n--'):
             return True
     return False
-
-
-def render_template(path):
-    """ Load a spec. There may be templated password variables, which we render using Jinja. """
-    try:
-        dir_path, filename = os.path.split(path)
-        environment = jinja2.Environment(loader=jinja2.FileSystemLoader(dir_path),
-                                         undefined=jinja2.StrictUndefined)
-        loaded = environment.get_template(filename)
-        rendered = loaded.render(env=os.environ)
-    except jinja2.exceptions.TemplateNotFound as err:
-        common.fail(FILE_OPEN_ERROR_MSG.format(path, err))
-    except jinja2.exceptions.UndefinedError as err:
-        common.fail(MISSING_ENVVAR_MSG.format(err))
-    else:
-        return rendered
 
 
 def run_module_sql(module_sql, cursor, verbose):
@@ -138,119 +65,7 @@ def run_password_sql(cursor, all_password_sql_to_run):
         common.fail(msg=common.FAILED_QUERY_MSG.format(query, e))
 
 
-def verify_schema(spec):
-    """Checks spec for schema errors."""
-    error_messages = []
-
-    schema = yaml.load(SPEC_SCHEMA_YAML)
-    v = cerberus.Validator(schema)
-    for rolename, config in spec.items():
-        if not config:
-            continue
-        v.validate(config)
-        for field, err_msg in v.errors.items():
-            error_messages.append(VALIDATION_ERR_MSG.format(rolename, field, err_msg[0]))
-
-    return error_messages
-
-
-def check_for_multi_schema_owners(spec):
-    """Checks spec for schema with multiple owners."""
-    error_messages = []
-
-    globally_owned_schemas = defaultdict(list)
-    for role, config in spec.items():
-        if not config:
-            continue
-        if config.get('has_personal_schema'):
-            # indicates a role has a personal schema with its same name
-            globally_owned_schemas[role].append(role)
-        if config.get('owns') and config['owns'].get('schemas'):
-            role_owned_schemas = config['owns']['schemas']
-            for schema in role_owned_schemas:
-                globally_owned_schemas[schema].append(role)
-    for schema, owners in globally_owned_schemas.items():
-        if len(owners) > 1:
-            owners_formatted = ", ".join(owners)
-            error_messages.append(MULTIPLE_SCHEMA_OWNER_ERR_MSG.format(schema, owners_formatted))
-
-    return error_messages
-
-
-def check_read_write_obj_references(spec):
-    """Verifies objects aren't defined in both read and write privileges sections."""
-    error_messages = []
-
-    multi_refs = defaultdict(dict)
-    for role, config in spec.items():
-        if config and config.get('privileges'):
-            for obj in config['privileges']:
-                try:
-                    reads = set(config['privileges'][obj]['read'])
-                    writes = set(config['privileges'][obj]['write'])
-                    duplicates = reads.intersection(writes)
-                    if duplicates:
-                        multi_refs[role][obj] = list(duplicates)
-                except KeyError:
-                    continue
-    if multi_refs:
-        multi_ref_strings = ["%s: %s" % (k, v) for k, v in multi_refs.items()]
-        multi_ref_err_string = "\n\t".join(multi_ref_strings)
-        error_messages.append(OBJECT_REF_READ_WRITE_ERR.format(multi_ref_err_string))
-
-    return error_messages
-
-
-def detect_multiple_role_definitions(rendered_spec_template):
-    """Checks spec for roles declared multiple times.
-
-    In a spec template, if a role is declared more than once there exists a risk that the re-declaration will
-    override the desired configuration. pgbedrock considers a config containing this risk to be invalid and
-    will throw an error.
-
-    To accomplish this, the yaml.loader.Loader object is used to convert spec template
-    into a document tree.  Then, the root object's child nodes (which are the roles) are checked for duplicates.
-
-    Outputs:
-        []string    The decision to return a list of strings was deliberate, despite
-                    the fact that the length of the list can at most be one. The reason for this
-                    is that the other spec verification functions
-                    (check_for_multi_schema_owners and check_read_write_obj_references, verify_schema)
-                    also return a list of strings.  This return signature consistency makes the code
-                    in the verify_spec function cleaner.
-    """
-    error_messages = []
-    loader = yaml.loader.Loader(rendered_spec_template)
-    document_tree = loader.get_single_node()
-    if document_tree is None:
-        return None
-
-    role_definitions = defaultdict(int)
-    for node in document_tree.value:
-        role_definitions[node[0].value] += 1
-    multi_defined_roles = [k for k, v in role_definitions.items() if v > 1]
-    if multi_defined_roles:
-        error_message = " ,".join(multi_defined_roles)
-        error_messages = [DUPLICATE_ROLE_DEFINITIONS_ERR_MSG.format(error_message)]
-
-    return error_messages
-
-
-def verify_spec(rendered_template, spec):
-    assert isinstance(spec, dict)
-
-    error_messages = []
-    error_messages += detect_multiple_role_definitions(rendered_template)
-    verification_functions = (verify_schema,
-                              check_for_multi_schema_owners,
-                              check_read_write_obj_references)
-    for fn in verification_functions:
-        error_messages += fn(spec)
-    if error_messages:
-        common.fail('\n'.join(error_messages))
-
-
-def configure(spec, host, port, user, password, dbname, prompt, attributes, memberships,
+def configure(spec_path, host, port, user, password, dbname, prompt, attributes, memberships,
               ownerships, privileges, live, verbose):
     """
     Configure the role attributes, memberships, object ownerships, and/or privileges of a
@@ -262,7 +77,7 @@ def configure(spec, host, port, user, password, dbname, prompt, attributes, memb
 
     Inputs:
 
-        spec - str; the path for the configuration file
+        spec_path - str; the path for the configuration file
 
         host - str; the database server host
 
@@ -302,14 +117,10 @@ def configure(spec, host, port, user, password, dbname, prompt, attributes, memb
     db_connection = common.get_db_connection(host, port, dbname, user, password)
     cursor = db_connection.cursor(cursor_factory=psycopg2.extras.DictCursor)
 
-
-    rendered_template = render_template(spec)
-    spec = yaml.load(rendered_template)
-    verify_spec(rendered_template, spec)
+    spec = load_spec(spec_path)
 
     sql_to_run = []
     password_changed = False  # Initialize this in case the attributes module isn't run
-
 
     if attributes:
         sql_to_run.append(create_divider('attributes'))

--- a/pgbedrock/spec_inspector.py
+++ b/pgbedrock/spec_inspector.py
@@ -1,0 +1,200 @@
+from collections import defaultdict
+import os
+
+import cerberus
+import jinja2
+import yaml
+
+from pgbedrock import common
+
+
+DUPLICATE_ROLE_DEFINITIONS_ERR_MSG = 'Spec error: role(s) defined more than once: {}'
+FILE_OPEN_ERROR_MSG = "Unable to open file '{}':\n{}"
+MISSING_ENVVAR_MSG = "Required environment variable not found:\n{}"
+MULTIPLE_SCHEMA_OWNER_ERR_MSG = 'Spec error: schema "{}" owned by more than one role: {}'
+OBJECT_REF_READ_WRITE_ERR = (
+    'Spec error: objects have been unnecessarily given both read and write privileges.'
+    'pgbedrock automatically grants read access when write access is requested.\n\t{}'
+)
+VALIDATION_ERR_MSG = 'Spec error: role "{}", field "{}": {}'
+
+SPEC_SCHEMA_YAML = """
+    can_login:
+        type: boolean
+    has_personal_schema:
+        type: boolean
+    is_superuser:
+        type: boolean
+    attributes:
+        type: list
+        schema:
+            type: string
+            forbidden:
+                - LOGIN
+                - NOLOGIN
+                - SUPERUSER
+                - NOSUPERUSER
+    member_of:
+        type: list
+        schema:
+            type: string
+    privileges:
+        type: dict
+        allowed:
+            - schemas
+            - sequences
+            - tables
+        valueschema:
+            type: dict
+            allowed:
+                - read
+                - write
+            valueschema:
+                type: list
+                schema:
+                    type: string
+    owns:
+        type: dict
+        allowed:
+            - schemas
+        valueschema:
+            type: list
+            schema:
+                type: string
+    """
+
+
+def check_for_multi_schema_owners(spec):
+    """Checks spec for schema with multiple owners."""
+    error_messages = []
+
+    globally_owned_schemas = defaultdict(list)
+    for role, config in spec.items():
+        if not config:
+            continue
+        if config.get('has_personal_schema'):
+            # indicates a role has a personal schema with its same name
+            globally_owned_schemas[role].append(role)
+        if config.get('owns') and config['owns'].get('schemas'):
+            role_owned_schemas = config['owns']['schemas']
+            for schema in role_owned_schemas:
+                globally_owned_schemas[schema].append(role)
+    for schema, owners in globally_owned_schemas.items():
+        if len(owners) > 1:
+            owners_formatted = ", ".join(owners)
+            error_messages.append(MULTIPLE_SCHEMA_OWNER_ERR_MSG.format(schema, owners_formatted))
+
+    return error_messages
+
+
+def check_read_write_obj_references(spec):
+    """Verifies objects aren't defined in both read and write privileges sections."""
+    error_messages = []
+
+    multi_refs = defaultdict(dict)
+    for role, config in spec.items():
+        if config and config.get('privileges'):
+            for obj in config['privileges']:
+                try:
+                    reads = set(config['privileges'][obj]['read'])
+                    writes = set(config['privileges'][obj]['write'])
+                    duplicates = reads.intersection(writes)
+                    if duplicates:
+                        multi_refs[role][obj] = list(duplicates)
+                except KeyError:
+                    continue
+    if multi_refs:
+        multi_ref_strings = ["%s: %s" % (k, v) for k, v in multi_refs.items()]
+        multi_ref_err_string = "\n\t".join(multi_ref_strings)
+        error_messages.append(OBJECT_REF_READ_WRITE_ERR.format(multi_ref_err_string))
+
+    return error_messages
+
+
+def detect_multiple_role_definitions(rendered_spec_template):
+    """Checks spec for roles declared multiple times.
+
+    In a spec template, if a role is declared more than once there exists a risk that the
+    re-declaration will override the desired configuration. pgbedrock considers a config containing
+    this risk to be invalid and will throw an error.
+
+    To accomplish this, the yaml.loader.Loader object is used to convert spec template into a
+    document tree.  Then, the root object's child nodes (which are the roles) are checked for
+    duplicates.
+
+    Outputs a list of strings.
+
+    The decision to return a list of strings was deliberate, despite the fact that the length of the
+    list can at most be one. The reason for this is that the other spec verification functions
+    (check_for_multi_schema_owners and check_read_write_obj_references, verify_schema) also return a
+    list of strings.  This return signature consistency makes the code in the verify_spec function
+    cleaner.
+    """
+    error_messages = []
+    loader = yaml.loader.Loader(rendered_spec_template)
+    document_tree = loader.get_single_node()
+    if document_tree is None:
+        return None
+
+    role_definitions = defaultdict(int)
+    for node in document_tree.value:
+        role_definitions[node[0].value] += 1
+    multi_defined_roles = [k for k, v in role_definitions.items() if v > 1]
+    if multi_defined_roles:
+        error_message = " ,".join(multi_defined_roles)
+        error_messages = [DUPLICATE_ROLE_DEFINITIONS_ERR_MSG.format(error_message)]
+
+    return error_messages
+
+
+def load_spec(spec_path):
+    rendered_template = render_template(spec_path)
+    spec = yaml.load(rendered_template)
+    verify_spec(rendered_template, spec)
+    return spec
+
+
+def render_template(path):
+    """ Load a spec. There may be templated password variables, which we render using Jinja. """
+    try:
+        dir_path, filename = os.path.split(path)
+        environment = jinja2.Environment(loader=jinja2.FileSystemLoader(dir_path),
+                                         undefined=jinja2.StrictUndefined)
+        loaded = environment.get_template(filename)
+        rendered = loaded.render(env=os.environ)
+    except jinja2.exceptions.TemplateNotFound as err:
+        common.fail(FILE_OPEN_ERROR_MSG.format(path, err))
+    except jinja2.exceptions.UndefinedError as err:
+        common.fail(MISSING_ENVVAR_MSG.format(err))
+    else:
+        return rendered
+
+
+def verify_schema(spec):
+    """Checks spec for schema errors."""
+    error_messages = []
+
+    schema = yaml.load(SPEC_SCHEMA_YAML)
+    v = cerberus.Validator(schema)
+    for rolename, config in spec.items():
+        if not config:
+            continue
+        v.validate(config)
+        for field, err_msg in v.errors.items():
+            error_messages.append(VALIDATION_ERR_MSG.format(rolename, field, err_msg[0]))
+
+    return error_messages
+
+
+def verify_spec(rendered_template, spec):
+    assert isinstance(spec, dict)
+
+    error_messages = []
+    error_messages += detect_multiple_role_definitions(rendered_template)
+    verification_functions = (verify_schema,
+                              check_for_multi_schema_owners,
+                              check_read_write_obj_references)
+    for fn in verification_functions:
+        error_messages += fn(spec)
+    if error_messages:
+        common.fail('\n'.join(error_messages))

--- a/tests/test_core_configure.py
+++ b/tests/test_core_configure.py
@@ -1,8 +1,6 @@
 import copy
-import os
 
 import pytest
-import yaml
 
 from pgbedrock import core_configure
 from pgbedrock import ownerships as own
@@ -11,207 +9,6 @@ from pgbedrock import attributes as attr
 from test_ownerships import Q_SCHEMA_EXISTS
 from test_memberships import Q_HAS_ROLE
 from test_privileges import Q_HAS_PRIVILEGE
-
-
-@pytest.fixture
-def set_envvar(request):
-    """ Set an environment variable. We use a fixture to ensure cleanup if the test fails """
-    k, v = request.param
-    os.environ[k] = v
-    yield
-    del os.environ[k]
-
-
-def test_render_template(tmpdir):
-    spec_path = tmpdir.join('spec.yml')
-    spec_path.write("""
-        fred:
-          can_login: yes
-
-        my_group:
-          can_login: no
-
-        admin:
-          can_login: yes
-          is_superuser: yes
-          options:
-              - CREATEDB
-              - CREATEROLE
-              - REPLICATION
-
-        service1:
-          can_login: yes
-          schemas:
-              - service1_schema
-    """)
-    spec = core_configure.render_template(spec_path.strpath)
-    spec = yaml.load(spec)
-
-    assert len(spec) == 4
-    assert set(spec.keys()) == {'admin', 'my_group', 'service1', 'fred'}
-
-
-@pytest.mark.parametrize('set_envvar', [('FRED_PASSWORD', 'a_password')], indirect=True)
-def test_load_spec_with_templated_variables(tmpdir, set_envvar):
-    spec_path = tmpdir.join('spec.yml')
-    spec_path.write("""
-        fred:
-          can_login: yes
-          options:
-            - PASSWORD: "{{ env['FRED_PASSWORD'] }}"
-    """)
-    spec = core_configure.render_template(spec_path.strpath)
-    spec = yaml.load(spec)
-
-    password_option = spec['fred']['options'][0]
-    assert password_option['PASSWORD'] == 'a_password'
-
-
-def test_load_spec_fails_missing_templated_envvars(capsys, tmpdir):
-    envvar_name = 'MISSING_ENVVAR'
-    assert envvar_name not in os.environ
-
-    spec = """
-        fred:
-          can_login: yes
-          options:
-            - PASSWORD: "{{ env['%s'] }}"
-    """ % envvar_name
-    spec_path = tmpdir.join('spec.yml')
-    spec_path.write(spec)
-
-    with pytest.raises(SystemExit):
-        core_configure.render_template(spec_path.strpath)
-
-    out, err = capsys.readouterr()
-    expected = core_configure.MISSING_ENVVAR_MSG.format('')
-    assert expected in out
-    assert envvar_name in out
-
-
-def test_load_spec_fails_file_not_found(capsys):
-    filename = 'non_existent.yml'
-    dirname = os.path.dirname(__file__)
-    path = os.path.join(dirname, filename)
-
-    with pytest.raises(SystemExit):
-        core_configure.render_template(path)
-
-    out, _ = capsys.readouterr()
-    assert core_configure.FILE_OPEN_ERROR_MSG.format(path, '') in out
-
-
-def test_verify_spec_fails(capsys):
-    """ We could check more functionality, but at that point we'd just be testing cerberus. This
-    test is just to verify that a failure will happen and will be presented as we'd expect """
-    spec_yaml = """
-        fred:
-            attribute:
-                - flub
-        """
-    spec = yaml.load(spec_yaml)
-    errors = core_configure.verify_schema(spec)
-    expected = core_configure.VALIDATION_ERR_MSG.format('fred', 'attribute', 'unknown field')
-    assert expected == errors[0]
-
-
-def test_verify_spec_succeeds(capsys):
-    spec_yaml = """
-        fred:
-            attributes:
-                - flub
-
-        mark:
-        """
-    spec = yaml.load(spec_yaml)
-    errors = core_configure.verify_schema(spec)
-    assert len(errors) == 0
-
-
-def test_verify_spec_fails_multiple_roles_own_schema(capsys):
-    spec_yaml = """
-    jfinance:
-        owns:
-            schemas:
-                - finance_documents
-    jfauxnance:
-        owns:
-            schemas:
-                - finance_documents
-    """
-    spec = yaml.load(spec_yaml)
-    errors = core_configure.check_for_multi_schema_owners(spec)
-    expected = core_configure.MULTIPLE_SCHEMA_OWNER_ERR_MSG.format('finance_documents', 'jfinance, jfauxnance')
-    assert [expected] == errors
-
-
-def test_verify_spec_fails_multiple_roles_own_schema_personal_schema(capsys):
-    spec_yaml = """
-    jfinance:
-        has_personal_schema: yes
-        owns:
-            schemas:
-                - finance_documents
-    jfauxnance:
-        owns:
-            schemas:
-                - jfinance
-    """
-    spec = yaml.load(spec_yaml)
-    errors = core_configure.check_for_multi_schema_owners(spec)
-    expected = core_configure.MULTIPLE_SCHEMA_OWNER_ERR_MSG.format('jfinance', 'jfinance, jfauxnance')
-    assert [expected] == errors
-
-
-def test_verify_spec_fails_role_defined_multiple_times(tmpdir, capsys):
-    spec_path = tmpdir.join('spec.yml')
-    spec_path.write("""
-    jfinance:
-        owns:
-            schemas:
-                - finance_documents
-    jfinance:
-        owns:
-            schemas:
-                - even_more_finance_documents
-    patty:
-        owns:
-            schemas:
-                - tupperwear
-    """)
-    rendered_template = core_configure.render_template(spec_path.strpath)
-    errors = core_configure.detect_multiple_role_definitions(rendered_template)
-    expected = core_configure.DUPLICATE_ROLE_DEFINITIONS_ERR_MSG.format('jfinance')
-    assert [expected] == errors
-
-
-def test_verify_spec_fails_object_referenced_read_write(capsys):
-    spec_yaml = """
-    margerie:
-        can_login: true
-        privileges:
-            {}:
-                read:
-                    - big_bad
-                write:
-                    - big_bad
-    danil:
-        can_login: true
-        privileges:
-            sequences:
-                read:
-                    - hoop
-                write:
-                    - grok
-    """
-
-    privilege_types = ('schemas', 'sequences', 'tables')
-    for t in privilege_types:
-        spec = yaml.load(spec_yaml.format(t))
-        errors = core_configure.check_read_write_obj_references(spec)
-        err_string = "margerie: {'%s': ['big_bad']}" % t
-        expected = core_configure.OBJECT_REF_READ_WRITE_ERR.format(err_string)
-        assert [expected] == errors
 
 
 @pytest.mark.parametrize('statements, expected', [
@@ -249,7 +46,7 @@ def test_configure_no_changes_needed(tmpdir, capsys, db_config):
 
     params = copy.deepcopy(db_config)
     params.update(
-        dict(spec=spec_path.strpath,
+        dict(spec_path=spec_path.strpath,
              prompt=False,
              attributes=True,
              memberships=True,
@@ -277,7 +74,7 @@ def test_configure_live_mode_works(capsys, cursor, tiny_spec, db_config, live_mo
 
     params = copy.deepcopy(db_config)
     params.update(
-        dict(spec=tiny_spec,
+        dict(spec_path=tiny_spec,
              prompt=False,
              attributes=True,
              memberships=True,
@@ -340,7 +137,7 @@ def test_configure_live_does_not_leak_passwords(tmpdir, capsys, cursor, db_confi
 
     params = copy.deepcopy(db_config)
     params.update(
-        dict(spec=spec_path.strpath,
+        dict(spec_path=spec_path.strpath,
              prompt=False,
              attributes=True,
              memberships=True,
@@ -387,7 +184,7 @@ def test_no_password_attribute_makes_password_none(capsys, cursor, tiny_spec, db
 
     params = copy.deepcopy(db_config)
     params.update(
-        dict(spec=tiny_spec,
+        dict(spec_path=tiny_spec,
              prompt=False,
              attributes=True,
              memberships=True,
@@ -434,7 +231,7 @@ def test_configure_schema_role_has_dash(tmpdir, capsys, db_config):
 
     params = copy.deepcopy(db_config)
     params.update(
-        dict(spec=spec_path.strpath,
+        dict(spec_path=spec_path.strpath,
              prompt=False,
              attributes=True,
              memberships=True,

--- a/tests/test_spec_inspector.py
+++ b/tests/test_spec_inspector.py
@@ -1,0 +1,207 @@
+import os
+
+import pytest
+import yaml
+
+from pgbedrock import spec_inspector
+
+
+@pytest.fixture
+def set_envvar(request):
+    """ Set an environment variable. We use a fixture to ensure cleanup if the test fails """
+    k, v = request.param
+    os.environ[k] = v
+    yield
+    del os.environ[k]
+
+
+def test_verify_spec_fails_multiple_roles_own_schema(capsys):
+    spec_yaml = """
+    jfinance:
+        owns:
+            schemas:
+                - finance_documents
+    jfauxnance:
+        owns:
+            schemas:
+                - finance_documents
+    """
+    spec = yaml.load(spec_yaml)
+    errors = spec_inspector.check_for_multi_schema_owners(spec)
+    expected = spec_inspector.MULTIPLE_SCHEMA_OWNER_ERR_MSG.format('finance_documents', 'jfinance, jfauxnance')
+    assert [expected] == errors
+
+
+def test_verify_spec_fails_multiple_roles_own_schema_personal_schema(capsys):
+    spec_yaml = """
+    jfinance:
+        has_personal_schema: yes
+        owns:
+            schemas:
+                - finance_documents
+    jfauxnance:
+        owns:
+            schemas:
+                - jfinance
+    """
+    spec = yaml.load(spec_yaml)
+    errors = spec_inspector.check_for_multi_schema_owners(spec)
+    expected = spec_inspector.MULTIPLE_SCHEMA_OWNER_ERR_MSG.format('jfinance', 'jfinance, jfauxnance')
+    assert [expected] == errors
+
+
+def test_verify_spec_fails_object_referenced_read_write(capsys):
+    spec_yaml = """
+    margerie:
+        can_login: true
+        privileges:
+            {}:
+                read:
+                    - big_bad
+                write:
+                    - big_bad
+    danil:
+        can_login: true
+        privileges:
+            sequences:
+                read:
+                    - hoop
+                write:
+                    - grok
+    """
+
+    privilege_types = ('schemas', 'sequences', 'tables')
+    for t in privilege_types:
+        spec = yaml.load(spec_yaml.format(t))
+        errors = spec_inspector.check_read_write_obj_references(spec)
+        err_string = "margerie: {'%s': ['big_bad']}" % t
+        expected = spec_inspector.OBJECT_REF_READ_WRITE_ERR.format(err_string)
+        assert [expected] == errors
+
+
+def test_verify_spec_fails_role_defined_multiple_times(tmpdir, capsys):
+    spec_path = tmpdir.join('spec.yml')
+    spec_path.write("""
+    jfinance:
+        owns:
+            schemas:
+                - finance_documents
+    jfinance:
+        owns:
+            schemas:
+                - even_more_finance_documents
+    patty:
+        owns:
+            schemas:
+                - tupperwear
+    """)
+    rendered_template = spec_inspector.render_template(spec_path.strpath)
+    errors = spec_inspector.detect_multiple_role_definitions(rendered_template)
+    expected = spec_inspector.DUPLICATE_ROLE_DEFINITIONS_ERR_MSG.format('jfinance')
+    assert [expected] == errors
+
+
+def test_verify_spec_fails(capsys):
+    """ We could check more functionality, but at that point we'd just be testing cerberus. This
+    test is just to verify that a failure will happen and will be presented as we'd expect """
+    spec_yaml = """
+        fred:
+            attribute:
+                - flub
+        """
+    spec = yaml.load(spec_yaml)
+    errors = spec_inspector.verify_schema(spec)
+    expected = spec_inspector.VALIDATION_ERR_MSG.format('fred', 'attribute', 'unknown field')
+    assert expected == errors[0]
+
+
+def test_verify_spec_succeeds(capsys):
+    spec_yaml = """
+        fred:
+            attributes:
+                - flub
+
+        mark:
+        """
+    spec = yaml.load(spec_yaml)
+    errors = spec_inspector.verify_schema(spec)
+    assert len(errors) == 0
+
+
+def test_render_template(tmpdir):
+    spec_path = tmpdir.join('spec.yml')
+    spec_path.write("""
+        fred:
+          can_login: yes
+
+        my_group:
+          can_login: no
+
+        admin:
+          can_login: yes
+          is_superuser: yes
+          options:
+              - CREATEDB
+              - CREATEROLE
+              - REPLICATION
+
+        service1:
+          can_login: yes
+          schemas:
+              - service1_schema
+    """)
+    spec = spec_inspector.render_template(spec_path.strpath)
+    spec = yaml.load(spec)
+
+    assert len(spec) == 4
+    assert set(spec.keys()) == {'admin', 'my_group', 'service1', 'fred'}
+
+
+@pytest.mark.parametrize('set_envvar', [('FRED_PASSWORD', 'a_password')], indirect=True)
+def test_load_spec_with_templated_variables(tmpdir, set_envvar):
+    spec_path = tmpdir.join('spec.yml')
+    spec_path.write("""
+        fred:
+          can_login: yes
+          options:
+            - PASSWORD: "{{ env['FRED_PASSWORD'] }}"
+    """)
+    spec = spec_inspector.render_template(spec_path.strpath)
+    spec = yaml.load(spec)
+
+    password_option = spec['fred']['options'][0]
+    assert password_option['PASSWORD'] == 'a_password'
+
+
+def test_load_spec_fails_missing_templated_envvars(capsys, tmpdir):
+    envvar_name = 'MISSING_ENVVAR'
+    assert envvar_name not in os.environ
+
+    spec = """
+        fred:
+          can_login: yes
+          options:
+            - PASSWORD: "{{ env['%s'] }}"
+    """ % envvar_name
+    spec_path = tmpdir.join('spec.yml')
+    spec_path.write(spec)
+
+    with pytest.raises(SystemExit):
+        spec_inspector.render_template(spec_path.strpath)
+
+    out, err = capsys.readouterr()
+    expected = spec_inspector.MISSING_ENVVAR_MSG.format('')
+    assert expected in out
+    assert envvar_name in out
+
+
+def test_load_spec_fails_file_not_found(capsys):
+    filename = 'non_existent.yml'
+    dirname = os.path.dirname(__file__)
+    path = os.path.join(dirname, filename)
+
+    with pytest.raises(SystemExit):
+        spec_inspector.render_template(path)
+
+    out, _ = capsys.readouterr()
+    assert spec_inspector.FILE_OPEN_ERROR_MSG.format(path, '') in out


### PR DESCRIPTION
We have several hundred lines of spec-related code, most of which does
validation of various conditions. As we will be adding more validation
soon (e.g. when we add table and sequence support) and more parsing
logic soon (e.g. when we add multi-database support), it makes sense to
extract this functionality into a submodule so we don't clutter the
core_configure module and we keep related functionality close to each
other.