### PR TITLE
Add table and sequence ownership to pgbedrock

### DIFF
--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -208,6 +208,8 @@ PRIVILEGE_MAP = {
 }
 
 ObjectInfo = namedtuple('ObjectInfo', ['kind', 'name', 'owner', 'is_dependent'])
+ObjectAttributes = namedtuple('ObjectAttributes',
+                              ['kind', 'schema', 'name', 'owner', 'is_dependent'])
 
 
 class DatabaseContext(object):
@@ -401,8 +403,6 @@ class DatabaseContext(object):
         The results are used in several subsequent methods, so having consistent results is
         important. Thus, this helper method is here to ensure that we only run this query once.
         """
-        ObjectAttributes = namedtuple('ObjectAttributes',
-                                      ['kind', 'schema', 'name', 'owner', 'is_dependent'])
         common.run_query(self.cursor, self.verbose, Q_GET_ALL_RAW_OBJECT_ATTRIBUTES)
         results = [ObjectAttributes(*row) for row in self.cursor.fetchall()]
         return results

--- a/pgbedrock/core_configure.py
+++ b/pgbedrock/core_configure.py
@@ -8,7 +8,7 @@ from pgbedrock import LOG_FORMAT
 from pgbedrock import common
 from pgbedrock.attributes import analyze_attributes
 from pgbedrock.memberships import analyze_memberships
-from pgbedrock.ownerships import analyze_schemas
+from pgbedrock.ownerships import analyze_ownerships
 from pgbedrock.privileges import analyze_privileges
 from pgbedrock.spec_inspector import load_spec
 
@@ -142,7 +142,7 @@ def configure(spec_path, host, port, user, password, dbname, prompt, attributes,
 
     if ownerships:
         sql_to_run.append(create_divider('ownerships'))
-        module_sql = analyze_schemas(spec, cursor, verbose)
+        module_sql = analyze_ownerships(spec, cursor, verbose)
         run_module_sql(module_sql, cursor, verbose)
         sql_to_run.extend(module_sql)
 

--- a/pgbedrock/core_configure.py
+++ b/pgbedrock/core_configure.py
@@ -117,7 +117,7 @@ def configure(spec_path, host, port, user, password, dbname, prompt, attributes,
     db_connection = common.get_db_connection(host, port, dbname, user, password)
     cursor = db_connection.cursor(cursor_factory=psycopg2.extras.DictCursor)
 
-    spec = load_spec(spec_path)
+    spec = load_spec(spec_path, cursor, verbose, attributes, memberships, ownerships, privileges)
 
     sql_to_run = []
     password_changed = False  # Initialize this in case the attributes module isn't run

--- a/pgbedrock/core_generate.py
+++ b/pgbedrock/core_generate.py
@@ -83,75 +83,75 @@ def add_schema_ownerships(spec, dbcontext):
             # log in is assumed to be a personal schema. See docstring for implications
             spec[owner]['has_personal_schema'] = True
         else:
-            try:
-                spec[owner]['owns']['schemas'].append(schema)
-            except KeyError:
-                spec[owner]['owns'] = {
-                    'schemas': [schema]
-                }
+            if 'owns' not in spec[owner]:
+                spec[owner]['owns'] = {'schemas': []}
+            elif 'schemas' not in spec[owner]['owns']:
+                spec[owner]['owns']['schemas'] = []
+
+            spec[owner]['owns']['schemas'].append(schema)
 
     return spec
 
 
-def add_nonschema_ownerships(spec, dbcontext):
+def add_nonschema_ownerships(spec, dbcontext, objkind):
     """
-    Add non-schema ownerships to an existing spec
+    Add non-schema ownerships for a specific object kind (e.g. tables, sequences, etc.) to an
+    existing spec.
 
     Objects that are dependent on other objects are skipped as we cannot configure their ownership;
     their ownership is tied to the object they depend on. Additionally, objects in personal schemas
     are skipped as they are managed by ownerships.py as part of the personal schema ownership.
     """
-    all_objects_and_owners = dbcontext.get_all_object_attributes()
     personal_schemas = dbcontext.get_all_personal_schemas()
+    all_objects_and_owners = dbcontext.get_all_object_attributes()
+    objects_and_owners = all_objects_and_owners.get(objkind)
 
-    for objkind in PRIVILEGE_MAP.keys():
-        if objkind == 'schemas':
+    for schema, objects_and_attributes in objects_and_owners.items():
+        # Skip objects in personal schemas; their ownership is already managed by ownerships.py
+        if schema in personal_schemas:
             continue
 
-        objects_and_owners = all_objects_and_owners.get(objkind)
-        for schema, objects_and_attributes in objects_and_owners.items():
-            # Skip objects in personal schemas; their ownership is already managed by ownerships.py
-            if schema in personal_schemas:
+        all_owners = set()
+        for objattr in objects_and_attributes.values():
+            if not objattr['is_dependent']:
+                all_owners.add(objattr['owner'])
+
+        # If all objects have the same owner, we just need to do 'schema.*' and we're done
+        if len(all_owners) == 1:
+            owner = list(all_owners)[0]
+
+            if 'owns' not in spec[owner]:
+                spec[owner]['owns'] = {objkind: []}
+            elif objkind not in spec[owner]['owns']:
+                spec[owner]['owns'][objkind] = []
+
+            spec[owner]['owns'][objkind].append('{}.*'.format(schema))
+
+            # Since all objects in this schema are owned by one role, we can skip the below
+            continue
+
+        for objname, objattr in objects_and_attributes.items():
+            # Skip dependent objects; their ownership is managed by the object they depend on
+            if objattr['is_dependent']:
                 continue
 
-            all_owners = set()
-            for objattr in objects_and_attributes.values():
-                if not objattr['is_dependent']:
-                    all_owners.add(objattr['owner'])
+            owner = objattr['owner']
+            if 'owns' not in spec[owner]:
+                spec[owner]['owns'] = {objkind: []}
+            elif objkind not in spec[owner]['owns']:
+                spec[owner]['owns'][objkind] = []
 
-            # If all objects have the same owner, we just need to do 'schema.*' and we're done
-            if len(all_owners) == 1:
-                owner = list(all_owners)[0]
-
-                if 'owns' not in spec[owner]:
-                    spec[owner]['owns'] = {objkind: []}
-                elif objkind not in spec[owner]['owns']:
-                    spec[owner]['owns'][objkind] = []
-
-                spec[owner]['owns'][objkind].append('{}.*'.format(schema))
-
-                # Since all objects in this schema are owned by one role, we can skip the below
-                continue
-
-            for objname, objattr in objects_and_attributes.items():
-                # Skip dependent objects; their ownership is managed by the object they depend on
-                if objattr['is_dependent']:
-                    continue
-
-                owner = objattr['owner']
-                if 'owns' not in spec[owner]:
-                    spec[owner]['owns'] = {objkind: []}
-                elif objkind not in spec[owner]['owns']:
-                    spec[owner]['owns'][objkind] = []
-
-                spec[owner]['owns'][objkind].append(objname)
+            spec[owner]['owns'][objkind].append(objname)
 
     return spec
 
 
 def add_ownerships(spec, dbcontext):
-    spec = add_schema_ownerships(spec, dbcontext)
-    spec = add_nonschema_ownerships(spec, dbcontext)
+    for objkind in PRIVILEGE_MAP.keys():
+        if objkind == 'schemas':
+            spec = add_schema_ownerships(spec, dbcontext)
+        else:
+            spec = add_nonschema_ownerships(spec, dbcontext, objkind)
     return spec
 
 

--- a/pgbedrock/core_generate.py
+++ b/pgbedrock/core_generate.py
@@ -74,10 +74,13 @@ def add_schema_ownerships(spec, dbcontext):
     objects in that schema that are not owned by the schema owner they will have their ownership
     changed (to be the same as the schema owner).
     """
+    personal_schemas = dbcontext.get_all_personal_schemas()
     schemas_and_owners = dbcontext.get_all_schemas_and_owners()
+
     for schema, owner in schemas_and_owners.items():
-        if schema == owner and spec[owner].get('can_login', False):
-            # This is (assumed to be) a personal schema. See docstring for implications
+        if schema in personal_schemas:
+            # Any schema where the owner is the same as the schema's name and the owner can
+            # log in is assumed to be a personal schema. See docstring for implications
             spec[owner]['has_personal_schema'] = True
         else:
             try:

--- a/pgbedrock/spec_inspector.py
+++ b/pgbedrock/spec_inspector.py
@@ -101,14 +101,15 @@ def ensure_no_object_owned_twice(spec, dbcontext, objkind):
                 for obj in nondependent_objects:
                     object_ownerships[obj].append(rolename)
             else:
-                object_ownerships[objname].append(rolename)
+                quoted_objname = common.ensure_quoted_identifier(objname)
+                object_ownerships[quoted_objname].append(rolename)
 
     error_messages = []
-    for objname, owners in object_ownerships.items():
+    for quoted_objname, owners in object_ownerships.items():
         if len(owners) > 1:
             owners_formatted = ", ".join(sorted(owners))
             error_messages.append(MULTIPLE_OBJKIND_OWNER_ERR_MSG.format(objkind[:-1].capitalize(),
-                                                                        objname, owners_formatted))
+                                                                        quoted_objname, owners_formatted))
 
     return error_messages
 
@@ -249,7 +250,8 @@ def ensure_no_missing_objects(spec, dbcontext, objkind):
                 for obj in nondependent_objects:
                     spec_objects.add(obj)
             else:
-                spec_objects.add(objname)
+                quoted_objname = common.ensure_quoted_identifier(objname)
+                spec_objects.add(quoted_objname)
 
     error_messages = []
 
@@ -300,14 +302,15 @@ def ensure_no_dependent_object_is_owned(spec, dbcontext, objkind):
                 continue
 
             schema = objname.split('.')[0]
+            quoted_objname = common.ensure_quoted_identifier(objname)
             try:
-                obj_is_dependent = all_db_objects[schema][objname]['is_dependent']
+                obj_is_dependent = all_db_objects[schema][quoted_objname]['is_dependent']
             except KeyError:
                 # This object is missing in the db; that condition already being checked elsewhere
                 continue
 
             if obj_is_dependent:
-                owned_dependent_objects.append(objname)
+                owned_dependent_objects.append(quoted_objname)
 
     if owned_dependent_objects:
         dep_objs = ', '.join(sorted(owned_dependent_objects))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,9 @@ def tiny_spec(tmpdir):
                 - information_schema
                 - pg_catalog
                 - public
+            tables:
+                - information_schema.*
+                - pg_catalog.*
 
     test_user:
         can_login: yes

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -38,17 +38,6 @@ def roleconf(request, mockdbcontext):
     return roleconf
 
 
-def test_analyze_attributes_undocumented_items(capsys, cursor):
-    # test_user and postgres user already existed (1st is created by docker when it starts
-    # postgres; 2nd is a postgres default). We simply don't put them in the spec here so they seem
-    # unexpected to our app, then verify that it treats them as unexpected
-    with pytest.raises(SystemExit):
-        attr.analyze_attributes(spec={}, cursor=cursor, verbose=False)
-
-    expected_err_msg = attr.UNDOCUMENTED_ROLES_MSG.format('"postgres", "test_user"') + '\n'
-    assert capsys.readouterr()[0] == expected_err_msg
-
-
 @run_setup_sql([
     attr.Q_CREATE_ROLE.format(ROLE1),
     ])

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -18,6 +18,16 @@ def test_check_name_succeeds():
     assert rolename == common.check_name(rolename)
 
 
+@pytest.mark.parametrize('input, expected', [
+    ('myschema.myschema.mytable', 'myschema."myschema.mytable"'),
+    ('myschema."myschema.mytable"', 'myschema."myschema.mytable"'),
+    ('myschema.mytable', 'myschema."mytable"'),
+    ('unqualified', 'unqualified'),
+])
+def test_ensure_quoted_identifier(input, expected):
+    assert common.ensure_quoted_identifier(input) == expected
+
+
 def test_get_db_connection_fails(capsys):
     with pytest.raises(SystemExit) as err:
         common.get_db_connection('foo', 'foo', 'foo', 'foo', 'foo')

--- a/tests/test_core_configure.py
+++ b/tests/test_core_configure.py
@@ -36,6 +36,9 @@ def test_configure_no_changes_needed(tmpdir, capsys, db_config):
                 - information_schema
                 - pg_catalog
                 - public
+            tables:
+                - information_schema.*
+                - pg_catalog.*
 
     test_user:
         can_login: yes
@@ -123,6 +126,9 @@ def test_configure_live_does_not_leak_passwords(tmpdir, capsys, cursor, db_confi
                 - information_schema
                 - pg_catalog
                 - public
+            tables:
+                - information_schema.*
+                - pg_catalog.*
 
     test_user:
         can_login: yes
@@ -218,6 +224,9 @@ def test_configure_schema_role_has_dash(tmpdir, capsys, db_config):
                 - information_schema
                 - pg_catalog
                 - public
+            tables:
+                - information_schema.*
+                - pg_catalog.*
 
     test_user:
         can_login: yes

--- a/tests/test_core_generate.py
+++ b/tests/test_core_generate.py
@@ -101,9 +101,11 @@ def test_add_schema_ownerships(mockdbcontext):
         # Personal schema
         'owner1': 'owner1',
 
-        # Would be personal schema but owner2 doesn't have 'can_login' within spec
+        # Would not show up in get_all_personal_schemas as can_login is False
         'owner2': 'owner2',
     }
+    mockdbcontext.get_all_personal_schemas = lambda: set(['owner1'])
+
     spec = {
         'owner1': {'can_login': True},
         'owner2': {},

--- a/tests/test_core_generate.py
+++ b/tests/test_core_generate.py
@@ -5,7 +5,7 @@ import textwrap
 import psycopg2
 import pytest
 
-from conftest import run_setup_sql
+from conftest import quoted_object, run_setup_sql
 from pgbedrock import attributes as attr
 from pgbedrock.context import DatabaseContext
 from pgbedrock import core_generate
@@ -91,7 +91,7 @@ def test_add_memberships(mockdbcontext):
     assert actual == expected
 
 
-def test_add_ownerships(mockdbcontext):
+def test_add_schema_ownerships(mockdbcontext):
     mockdbcontext.get_all_schemas_and_owners = lambda: {
         # Non-personal schemas
         'schema1': 'owner1',
@@ -109,7 +109,7 @@ def test_add_ownerships(mockdbcontext):
         'owner2': {},
     }
 
-    actual = core_generate.add_ownerships(spec, mockdbcontext)
+    actual = core_generate.add_schema_ownerships(spec, mockdbcontext)
 
     # There's no guarantee in what order the list of schemas will be returned,
     # so we have to convert the entries to a set to check equivalence
@@ -118,6 +118,80 @@ def test_add_ownerships(mockdbcontext):
     assert set(actual['owner1']['owns']['schemas']) == set(['schema1', 'schema2'])
     assert 'has_personal_schema' not in actual['owner2']
     assert set(actual['owner2']['owns']['schemas']) == set(['owner2', 'schema3'])
+
+
+def test_add_nonschema_ownerships(mockdbcontext):
+    mockdbcontext.get_all_object_attributes = lambda: {
+        'tables': {
+            'schema1': {
+                quoted_object('schema1', 'mytable1'): {'owner': 'owner1', 'is_dependent': False},
+                # This entry should be skipped because it is dependent
+                quoted_object('schema1', 'mytable2'): {'owner': 'owner2', 'is_dependent': True},
+                quoted_object('schema1', 'mytable3'): {'owner': 'owner2', 'is_dependent': False},
+            },
+            'schema2': {
+                # These all have the same owner, so it will become schema2.*
+                quoted_object('schema2', 'mytable4'): {'owner': 'owner1', 'is_dependent': False},
+                quoted_object('schema2', 'mytable5'): {'owner': 'owner1', 'is_dependent': False},
+                quoted_object('schema2', 'mytable6'): {'owner': 'owner1', 'is_dependent': False},
+            },
+            'owner4': {
+                # This entry should be skipped because it is in a personal schema
+                quoted_object('owner4', 'mytable7'): {'owner': 'owner2', 'is_dependent': False},
+            },
+        },
+        'sequences': {},
+    }
+    mockdbcontext.get_all_personal_schemas = lambda: set(['owner4', 'owner5'])
+
+    spec = {
+        'owner1': {
+            'owns': {
+                'schemas': ['schema1']
+            }
+        },
+        'owner2': {},
+        'owner3': {},
+        'owner4': {},
+        'owner5': {},
+    }
+
+    actual = core_generate.add_nonschema_ownerships(spec, mockdbcontext)
+    assert actual['owner1']['owns']['schemas'] == ['schema1']
+    assert set(actual['owner1']['owns']['tables']) == set([
+        quoted_object('schema1', 'mytable1'),
+        'schema2.*',
+    ])
+    assert actual['owner2']['owns']['tables'] == [quoted_object('schema1', 'mytable3')]
+    assert actual['owner3'] == {}
+    assert actual['owner4'] == {}
+    assert actual['owner5'] == {}
+
+
+def test_add_nonschema_ownerships_empty_objkinds(mockdbcontext):
+    mockdbcontext.get_all_object_attributes = lambda: {
+        'tables': {
+            'schema1': {},
+        },
+        'sequences': {},
+    }
+    mockdbcontext.get_all_personal_schemas = lambda: set(['owner4', 'owner5'])
+
+    spec = {
+        'owner1': {
+            'owns': {
+                'schemas': ['schema1']
+            }
+        },
+        'owner2': {},
+        'owner3': {},
+        'owner4': {},
+        'owner5': {},
+    }
+
+    actual = core_generate.add_nonschema_ownerships(spec, mockdbcontext)
+    # Make sure nothing changed
+    assert actual == spec
 
 
 @run_setup_sql([

--- a/tests/test_core_generate.py
+++ b/tests/test_core_generate.py
@@ -137,14 +137,14 @@ def test_add_nonschema_ownerships(mockdbcontext):
                 quoted_object('schema2', 'mytable5'): {'owner': 'owner1', 'is_dependent': False},
                 quoted_object('schema2', 'mytable6'): {'owner': 'owner1', 'is_dependent': False},
             },
-            'owner4': {
+            'owner3': {
                 # This entry should be skipped because it is in a personal schema
-                quoted_object('owner4', 'mytable7'): {'owner': 'owner2', 'is_dependent': False},
+                quoted_object('owner3', 'mytable7'): {'owner': 'owner2', 'is_dependent': False},
             },
         },
         'sequences': {},
     }
-    mockdbcontext.get_all_personal_schemas = lambda: set(['owner4', 'owner5'])
+    mockdbcontext.get_all_personal_schemas = lambda: set(['owner3', 'owner5'])
 
     spec = {
         'owner1': {
@@ -155,10 +155,9 @@ def test_add_nonschema_ownerships(mockdbcontext):
         'owner2': {},
         'owner3': {},
         'owner4': {},
-        'owner5': {},
     }
 
-    actual = core_generate.add_nonschema_ownerships(spec, mockdbcontext)
+    actual = core_generate.add_nonschema_ownerships(spec, mockdbcontext, 'tables')
     assert actual['owner1']['owns']['schemas'] == ['schema1']
     assert set(actual['owner1']['owns']['tables']) == set([
         quoted_object('schema1', 'mytable1'),
@@ -167,10 +166,10 @@ def test_add_nonschema_ownerships(mockdbcontext):
     assert actual['owner2']['owns']['tables'] == [quoted_object('schema1', 'mytable3')]
     assert actual['owner3'] == {}
     assert actual['owner4'] == {}
-    assert actual['owner5'] == {}
 
 
-def test_add_nonschema_ownerships_empty_objkinds(mockdbcontext):
+@pytest.mark.parametrize('objkind', [('tables'), ('sequences')])
+def test_add_nonschema_ownerships_empty_objkinds(mockdbcontext, objkind):
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             'schema1': {},
@@ -187,13 +186,78 @@ def test_add_nonschema_ownerships_empty_objkinds(mockdbcontext):
         },
         'owner2': {},
         'owner3': {},
-        'owner4': {},
-        'owner5': {},
     }
 
-    actual = core_generate.add_nonschema_ownerships(spec, mockdbcontext)
+    actual = core_generate.add_nonschema_ownerships(spec, mockdbcontext, objkind)
     # Make sure nothing changed
     assert actual == spec
+
+
+def test_add_ownerships(mockdbcontext):
+    mockdbcontext.get_all_object_attributes = lambda: {
+        'tables': {
+            'schema1': {
+                quoted_object('schema1', 'mytable1'): {'owner': 'owner1', 'is_dependent': False},
+                # This entry should be skipped because it is dependent
+                quoted_object('schema1', 'mytable2'): {'owner': 'owner2', 'is_dependent': True},
+                quoted_object('schema1', 'mytable3'): {'owner': 'owner2', 'is_dependent': False},
+            },
+            'schema2': {
+                # These all have the same owner, so it will become schema2.*
+                quoted_object('schema2', 'mytable4'): {'owner': 'owner1', 'is_dependent': False},
+                quoted_object('schema2', 'mytable5'): {'owner': 'owner1', 'is_dependent': False},
+                quoted_object('schema2', 'mytable6'): {'owner': 'owner1', 'is_dependent': False},
+            },
+            'owner3': {
+                # This entry should be skipped because it is in a personal schema
+                quoted_object('owner3', 'mytable7'): {'owner': 'owner2', 'is_dependent': False},
+            },
+        },
+        'sequences': {
+            'schema1': {
+                quoted_object('schema1', 'myseq1'): {'owner': 'owner2', 'is_dependent': False},
+                quoted_object('schema1', 'myseq2'): {'owner': 'owner3', 'is_dependent': True},
+            },
+            'schema2': {
+                quoted_object('schema2', 'myseq3'): {'owner': 'owner1', 'is_dependent': False},
+                quoted_object('schema2', 'myseq4'): {'owner': 'owner2', 'is_dependent': False},
+            },
+        },
+    }
+    mockdbcontext.get_all_schemas_and_owners = lambda: {
+        # Non-personal schemas
+        'schema1': 'owner1',
+        'schema2': 'owner1',
+
+        # Personal schema
+        'owner3': 'owner3',
+    }
+    mockdbcontext.get_all_personal_schemas = lambda: set(['owner3'])
+
+    spec = {
+        'owner1': {},
+        'owner2': {},
+        'owner3': {},
+    }
+
+    actual = core_generate.add_ownerships(spec, mockdbcontext)
+    # Schema ownership assertions
+    assert set(actual['owner1']['owns']['schemas']) == set(['schema1', 'schema2'])
+    assert actual['owner3'] == {'has_personal_schema': True}
+
+    # Table ownership assertions
+    assert set(actual['owner1']['owns']['tables']) == set([
+        quoted_object('schema1', 'mytable1'),
+        'schema2.*',
+    ])
+    assert actual['owner2']['owns']['tables'] == [quoted_object('schema1', 'mytable3')]
+
+    # Sequence ownership assertions
+    assert actual['owner1']['owns']['sequences'] == [quoted_object('schema2', 'myseq3')]
+    assert set(actual['owner2']['owns']['sequences']) == set([
+        'schema1.*',
+        quoted_object('schema2', 'myseq4')
+    ])
 
 
 @run_setup_sql([

--- a/tests/test_ownerships.py
+++ b/tests/test_ownerships.py
@@ -4,9 +4,10 @@ from pgbedrock import attributes, privileges
 from pgbedrock.context import ObjectInfo
 
 Q_CREATE_SEQUENCE = 'SET ROLE {}; CREATE SEQUENCE {}.{}; RESET ROLE;'
+Q_CREATE_TABLE = 'SET ROLE {}; CREATE TABLE {}.{} AS (SELECT 1+1); RESET ROLE;'
 Q_SCHEMA_EXISTS = "SELECT schema_name FROM information_schema.schemata WHERE schema_name='{}';"
 
-ROLES = tuple('role{}'.format(i) for i in range(2))
+ROLES = tuple('role{}'.format(i) for i in range(3))
 SCHEMAS = tuple('schema{}'.format(i) for i in range(3))
 TABLES = tuple('table{}'.format(i) for i in range(4))
 SEQUENCES = tuple('seq{}'.format(i) for i in range(4))
@@ -31,14 +32,6 @@ def test_analyze_ownerships_create_schemas(cursor):
                 'schemas': [SCHEMAS[1]],
             },
         },
-        'postgres': {
-            'owns': {
-                'schemas': [
-                    'information_schema',
-                    'pg_catalog',
-                ]
-            },
-        },
     }
     actual = own.analyze_ownerships(spec, cursor, verbose=False)
 
@@ -50,7 +43,111 @@ def test_analyze_ownerships_create_schemas(cursor):
     assert set(actual) == expected
 
 
-def test_init(mockdbcontext):
+@run_setup_sql([
+    'DROP SCHEMA public',
+    attributes.Q_CREATE_ROLE.format(ROLES[0]),
+    attributes.Q_CREATE_ROLE.format(ROLES[1]),
+    own.Q_CREATE_SCHEMA.format(SCHEMAS[0], ROLES[0]),
+    own.Q_CREATE_SCHEMA.format(SCHEMAS[1], ROLES[0]),
+    privileges.Q_GRANT_NONDEFAULT.format('CREATE', 'SCHEMA', SCHEMAS[0], ROLES[1]),
+    privileges.Q_GRANT_NONDEFAULT.format('CREATE', 'SCHEMA', SCHEMAS[1], ROLES[1]),
+
+    # Create tables in SCHEMAS[0], some of which aren't owned by ROLES[0]
+    Q_CREATE_TABLE.format(ROLES[0], SCHEMAS[0], TABLES[0]),
+    Q_CREATE_TABLE.format(ROLES[1], SCHEMAS[0], TABLES[1]),  #
+    Q_CREATE_TABLE.format(ROLES[1], SCHEMAS[0], TABLES[2]),  #
+    Q_CREATE_TABLE.format(ROLES[0], SCHEMAS[0], TABLES[3]),
+
+    # Create two sequences in SCHEMAS[1], one of which isn't owned by ROLES[1]
+    Q_CREATE_SEQUENCE.format(ROLES[1], SCHEMAS[1], SEQUENCES[0]),
+    Q_CREATE_SEQUENCE.format(ROLES[0], SCHEMAS[1], SEQUENCES[1]),
+    ])
+def test_analyze_ownerships_nonschemas(cursor):
+    spec = {
+        ROLES[0]: {
+            'owns': {
+                'tables': ['{}.*'.format(SCHEMAS[0])]
+            },
+        },
+        ROLES[1]: {
+            'owns': {
+                'sequences': [
+                    quoted_object(SCHEMAS[1], SEQUENCES[0]),
+                    quoted_object(SCHEMAS[1], SEQUENCES[1]),
+                ]
+            },
+        },
+    }
+    actual = own.analyze_ownerships(spec, cursor, verbose=False)
+
+    expected = set([
+        own.Q_SET_OBJECT_OWNER.format('TABLE', quoted_object(SCHEMAS[0], TABLES[1]),
+                                      ROLES[0], ROLES[1]),
+        own.Q_SET_OBJECT_OWNER.format('TABLE', quoted_object(SCHEMAS[0], TABLES[2]),
+                                      ROLES[0], ROLES[1]),
+        own.Q_SET_OBJECT_OWNER.format('SEQUENCE', quoted_object(SCHEMAS[1], SEQUENCES[1]),
+                                      ROLES[1], ROLES[0]),
+    ])
+    assert set(actual) == expected
+
+
+@run_setup_sql([
+    'DROP SCHEMA public',
+    attributes.Q_CREATE_ROLE.format(ROLES[0]),
+    attributes.Q_CREATE_ROLE.format(ROLES[1]),
+    own.Q_CREATE_SCHEMA.format(SCHEMAS[0], ROLES[0]),
+    own.Q_CREATE_SCHEMA.format(SCHEMAS[1], ROLES[0]),
+    privileges.Q_GRANT_NONDEFAULT.format('CREATE', 'SCHEMA', SCHEMAS[0], ROLES[1]),
+    privileges.Q_GRANT_NONDEFAULT.format('CREATE', 'SCHEMA', SCHEMAS[1], ROLES[1]),
+
+    # Create tables in SCHEMAS[0], some of which aren't owned by ROLES[0]
+    Q_CREATE_TABLE.format(ROLES[0], SCHEMAS[0], TABLES[0]),
+    Q_CREATE_TABLE.format(ROLES[1], SCHEMAS[0], TABLES[1]),  #
+    Q_CREATE_TABLE.format(ROLES[1], SCHEMAS[0], TABLES[2]),  #
+    Q_CREATE_TABLE.format(ROLES[0], SCHEMAS[0], TABLES[3]),
+
+    # Create two sequences in SCHEMAS[1], one of which isn't owned by ROLES[1]
+    Q_CREATE_SEQUENCE.format(ROLES[1], SCHEMAS[1], SEQUENCES[0]),
+    Q_CREATE_SEQUENCE.format(ROLES[0], SCHEMAS[1], SEQUENCES[1]),
+    ])
+def test_analyze_ownerships_schemas_and_nonschemas(cursor):
+    """
+    This is just a combination of the related schema and nonschema tests to make sure the pieces
+    fit together.
+    """
+    spec = {
+        ROLES[0]: {
+            'has_personal_schema': True,
+            'owns': {
+                'tables': ['{}.*'.format(SCHEMAS[0])],
+                'schemas': [SCHEMAS[2]],
+            },
+        },
+        ROLES[1]: {
+            'owns': {
+                'sequences': [
+                    quoted_object(SCHEMAS[1], SEQUENCES[0]),
+                    quoted_object(SCHEMAS[1], SEQUENCES[1]),
+                ]
+            },
+        },
+    }
+    actual = own.analyze_ownerships(spec, cursor, verbose=False)
+
+    expected = set([
+        own.Q_SET_OBJECT_OWNER.format('TABLE', quoted_object(SCHEMAS[0], TABLES[1]),
+                                      ROLES[0], ROLES[1]),
+        own.Q_SET_OBJECT_OWNER.format('TABLE', quoted_object(SCHEMAS[0], TABLES[2]),
+                                      ROLES[0], ROLES[1]),
+        own.Q_SET_OBJECT_OWNER.format('SEQUENCE', quoted_object(SCHEMAS[1], SEQUENCES[1]),
+                                      ROLES[1], ROLES[0]),
+        own.Q_CREATE_SCHEMA.format(ROLES[0], ROLES[0]),
+        own.Q_CREATE_SCHEMA.format(SCHEMAS[2], ROLES[0]),
+    ])
+    assert set(actual) == expected
+
+
+def test_schemaanalyzer_init(mockdbcontext):
     mockdbcontext.get_schema_owner = lambda x: 'foo'
     mockdbcontext.get_schema_objects = lambda x: 'bar'
     schemaconf = own.SchemaAnalyzer(rolename=ROLES[0], schema=SCHEMAS[0], dbcontext=mockdbcontext)
@@ -62,28 +159,28 @@ def test_init(mockdbcontext):
     assert schemaconf.schema_objects == 'bar'
 
 
-def test_analyze_create_schema(mockdbcontext):
+def test_schemaanalyzer_analyzer_creates_schema(mockdbcontext):
     schemaconf = own.SchemaAnalyzer(ROLES[0], schema=SCHEMAS[0], dbcontext=mockdbcontext)
     actual = schemaconf.analyze()
     expected = [own.Q_CREATE_SCHEMA.format(SCHEMAS[0], ROLES[0])]
     assert actual == expected
 
 
-def test_analyze_existing_schema_owner_change(mockdbcontext):
+def test_schemaanalyzer_existing_schema_owner_change(mockdbcontext):
     mockdbcontext.get_schema_owner = lambda x: ROLES[1]
     schemaconf = own.SchemaAnalyzer(ROLES[0], schema=SCHEMAS[0], dbcontext=mockdbcontext)
     changes = schemaconf.analyze()
     assert changes == [own.Q_SET_SCHEMA_OWNER.format(SCHEMAS[0], ROLES[0], ROLES[1])]
 
 
-def test_analyze_existing_schema_same_owner(mockdbcontext):
+def test_schemaanalyzer_existing_schema_same_owner(mockdbcontext):
     mockdbcontext.get_schema_owner = lambda x: ROLES[0]
     schemaconf = own.SchemaAnalyzer(ROLES[0], schema=SCHEMAS[0], dbcontext=mockdbcontext)
     changes = schemaconf.analyze()
     assert changes == []
 
 
-def test_analyze_existing_personal_schema_change_object_owners(mockdbcontext):
+def test_schemaanalyzer_existing_personal_schema_change_object_owners(mockdbcontext):
     mockdbcontext.get_schema_owner = lambda x: ROLES[0]
     mockdbcontext.get_schema_objects = lambda x: [
         ObjectInfo('tables', quoted_object(ROLES[0], TABLES[0]), ROLES[0], False),
@@ -103,14 +200,13 @@ def test_analyze_existing_personal_schema_change_object_owners(mockdbcontext):
     assert actual == expected
 
 
-def test_create_schema(mockdbcontext):
+def test_schemaanalyzer_create_schema(mockdbcontext):
     schemaconf = own.SchemaAnalyzer(ROLES[0], schema=SCHEMAS[0], dbcontext=mockdbcontext)
     schemaconf.create_schema()
-
     assert schemaconf.sql_to_run == [own.Q_CREATE_SCHEMA.format(SCHEMAS[0], ROLES[0])]
 
 
-def test_set_owner(mockdbcontext):
+def test_schemaanalyzer_set_owner(mockdbcontext):
     previous_owner = ROLES[1]
     mockdbcontext.get_schema_owner = lambda x: previous_owner
 
@@ -121,7 +217,7 @@ def test_set_owner(mockdbcontext):
     assert schemaconf.sql_to_run == expected
 
 
-def test_alter_object_owner(mockdbcontext):
+def test_schemaanalyzer_alter_object_owner(mockdbcontext):
     previous_owner = ROLES[1]
     owner = ROLES[0]
     schema = SCHEMAS[0]
@@ -133,7 +229,7 @@ def test_alter_object_owner(mockdbcontext):
     assert schemaconf.sql_to_run == [own.Q_SET_OBJECT_OWNER.format('TABLE', table_name, owner, previous_owner)]
 
 
-def test_get_improperly_owned_objects(mockdbcontext):
+def test_schemaanalyzer_get_improperly_owned_objects(mockdbcontext):
     mockdbcontext.get_schema_owner = lambda x: ROLES[0]
     mockdbcontext.get_schema_objects = lambda x: [
         # Properly owned
@@ -155,4 +251,77 @@ def test_get_improperly_owned_objects(mockdbcontext):
     actual = schemaconf.get_improperly_owned_objects()
     expected = [('tables', quoted_object(schema, TABLES[1]), ROLES[1]),
                 ('sequences', quoted_object(schema, SEQUENCES[1]), ROLES[1])]
+    assert set(actual) == set(expected)
+
+
+def test_nonschemaanalyzer_expand_schema_objects(mockdbcontext):
+    mockdbcontext.get_all_object_attributes = lambda: {
+        'tables': {
+            SCHEMAS[0]: {
+                quoted_object(SCHEMAS[0], TABLES[0]): {'owner': DUMMY, 'is_dependent': False},
+                quoted_object(SCHEMAS[0], TABLES[1]): {'owner': DUMMY, 'is_dependent': False},
+                quoted_object(SCHEMAS[0], TABLES[2]): {'owner': DUMMY, 'is_dependent': True},
+            },
+        },
+    }
+    nsa = own.NonschemaAnalyzer(rolename=ROLES[0], objname=DUMMY,
+                                objkind='tables', dbcontext=mockdbcontext)
+    actual = nsa.expand_schema_objects(SCHEMAS[0])
+    expected = [quoted_object(SCHEMAS[0], TABLES[0]), quoted_object(SCHEMAS[0], TABLES[1])]
+    assert set(actual) == set(expected)
+
+
+def test_nonschemaanalyzer_analyze_no_changed_needed(mockdbcontext):
+    objname = quoted_object(SCHEMAS[0], TABLES[0])
+    mockdbcontext.get_all_object_attributes = lambda: {
+        'tables': {
+            SCHEMAS[0]: {
+                objname: {'owner': ROLES[0], 'is_dependent': False},
+            },
+        },
+    }
+    nsa = own.NonschemaAnalyzer(rolename=ROLES[0], objname=objname,
+                                objkind='tables', dbcontext=mockdbcontext)
+    actual = nsa.analyze()
+    assert actual == []
+
+
+def test_nonschemaanalyzer_analyze_without_schema_expansion(mockdbcontext):
+    objname = quoted_object(SCHEMAS[0], TABLES[0])
+    mockdbcontext.get_all_object_attributes = lambda: {
+        'tables': {
+            SCHEMAS[0]: {
+                objname: {'owner': ROLES[1], 'is_dependent': False},
+            },
+        },
+    }
+    nsa = own.NonschemaAnalyzer(rolename=ROLES[0], objname=objname,
+                                objkind='tables', dbcontext=mockdbcontext)
+    actual = nsa.analyze()
+    expected = [own.Q_SET_OBJECT_OWNER.format('TABLE', objname, ROLES[0], ROLES[1])]
+    assert actual == expected
+
+
+def test_nonschemaanalyzer_analyze_with_schema_expansion(mockdbcontext):
+    mockdbcontext.get_all_object_attributes = lambda: {
+        'sequences': {
+            SCHEMAS[0]: {
+                quoted_object(SCHEMAS[0], SEQUENCES[0]): {'owner': ROLES[1], 'is_dependent': False},
+                quoted_object(SCHEMAS[0], SEQUENCES[1]): {'owner': ROLES[2], 'is_dependent': False},
+                # This will be skipped as the owner is correct
+                quoted_object(SCHEMAS[0], SEQUENCES[2]): {'owner': ROLES[0], 'is_dependent': False},
+                # This will be skipped as it is dependent
+                quoted_object(SCHEMAS[0], SEQUENCES[3]): {'owner': ROLES[1], 'is_dependent': True},
+            },
+        },
+    }
+    nsa = own.NonschemaAnalyzer(rolename=ROLES[0], objname='{}.*'.format(SCHEMAS[0]),
+                                objkind='sequences', dbcontext=mockdbcontext)
+    actual = nsa.analyze()
+    expected = [
+        own.Q_SET_OBJECT_OWNER.format('SEQUENCE', quoted_object(SCHEMAS[0], SEQUENCES[0]),
+                                      ROLES[0], ROLES[1]),
+        own.Q_SET_OBJECT_OWNER.format('SEQUENCE', quoted_object(SCHEMAS[0], SEQUENCES[1]),
+                                      ROLES[0], ROLES[2]),
+    ]
     assert set(actual) == set(expected)

--- a/tests/test_ownerships.py
+++ b/tests/test_ownerships.py
@@ -54,8 +54,8 @@ def test_analyze_ownerships_create_schemas(cursor):
 
     # Create tables in SCHEMAS[0], some of which aren't owned by ROLES[0]
     Q_CREATE_TABLE.format(ROLES[0], SCHEMAS[0], TABLES[0]),
-    Q_CREATE_TABLE.format(ROLES[1], SCHEMAS[0], TABLES[1]),  #
-    Q_CREATE_TABLE.format(ROLES[1], SCHEMAS[0], TABLES[2]),  #
+    Q_CREATE_TABLE.format(ROLES[1], SCHEMAS[0], TABLES[1]),
+    Q_CREATE_TABLE.format(ROLES[1], SCHEMAS[0], TABLES[2]),
     Q_CREATE_TABLE.format(ROLES[0], SCHEMAS[0], TABLES[3]),
 
     # Create two sequences in SCHEMAS[1], one of which isn't owned by ROLES[1]
@@ -102,8 +102,8 @@ def test_analyze_ownerships_nonschemas(cursor):
 
     # Create tables in SCHEMAS[0], some of which aren't owned by ROLES[0]
     Q_CREATE_TABLE.format(ROLES[0], SCHEMAS[0], TABLES[0]),
-    Q_CREATE_TABLE.format(ROLES[1], SCHEMAS[0], TABLES[1]),  #
-    Q_CREATE_TABLE.format(ROLES[1], SCHEMAS[0], TABLES[2]),  #
+    Q_CREATE_TABLE.format(ROLES[1], SCHEMAS[0], TABLES[1]),
+    Q_CREATE_TABLE.format(ROLES[1], SCHEMAS[0], TABLES[2]),
     Q_CREATE_TABLE.format(ROLES[0], SCHEMAS[0], TABLES[3]),
 
     # Create two sequences in SCHEMAS[1], one of which isn't owned by ROLES[1]

--- a/tests/test_ownerships.py
+++ b/tests/test_ownerships.py
@@ -17,21 +17,6 @@ DUMMY = 'foo'
 
 @run_setup_sql([
     'DROP SCHEMA public',
-    'CREATE SCHEMA {}'.format(SCHEMAS[0]),
-    ])
-def test_analyze_schemas_with_undocumented_items(capsys, cursor):
-    spec = {'postgres': {'has_personal_schema': False}}
-
-    with pytest.raises(SystemExit):
-        own.analyze_schemas(spec, cursor, verbose=False)
-
-    # Undocumented schemas will come back double-quoted
-    missing_schemas = '"information_schema", "pg_catalog", "schema0"'
-    assert capsys.readouterr()[0] == own.UNDOCUMENTED_SCHEMAS_MSG.format(missing_schemas) + "\n"
-
-
-@run_setup_sql([
-    'DROP SCHEMA public',
     attributes.Q_CREATE_ROLE.format(ROLES[0]),
     attributes.Q_CREATE_ROLE.format(ROLES[1]),
     ])
@@ -65,24 +50,6 @@ def test_analyze_schemas_create_schemas(cursor):
         own.Q_CREATE_SCHEMA.format(SCHEMAS[1], ROLES[1]),
     ])
     assert set(actual) == expected
-
-
-def test_get_spec_schemas():
-    spec = {
-        ROLES[0]: {
-             'has_personal_schema': True,
-             'owns': {
-                 'schemas': [SCHEMAS[0]]
-             },
-        },
-        ROLES[1]: {
-             'owns': {
-                 'schemas': [SCHEMAS[1]]
-             },
-        }
-    }
-
-    assert own.get_spec_schemas(spec) == set([ROLES[0], SCHEMAS[0], SCHEMAS[1]])
 
 
 def test_init(mockdbcontext):

--- a/tests/test_ownerships.py
+++ b/tests/test_ownerships.py
@@ -1,5 +1,3 @@
-import pytest
-
 from conftest import quoted_object, run_setup_sql
 from pgbedrock import ownerships as own
 from pgbedrock import attributes, privileges
@@ -20,7 +18,7 @@ DUMMY = 'foo'
     attributes.Q_CREATE_ROLE.format(ROLES[0]),
     attributes.Q_CREATE_ROLE.format(ROLES[1]),
     ])
-def test_analyze_schemas_create_schemas(cursor):
+def test_analyze_ownerships_create_schemas(cursor):
     spec = {
         ROLES[0]: {
             'has_personal_schema': True,
@@ -42,7 +40,7 @@ def test_analyze_schemas_create_schemas(cursor):
             },
         },
     }
-    actual = own.analyze_schemas(spec, cursor, verbose=False)
+    actual = own.analyze_ownerships(spec, cursor, verbose=False)
 
     expected = set([
         own.Q_CREATE_SCHEMA.format(ROLES[0], ROLES[0]),

--- a/tests/test_privileges.py
+++ b/tests/test_privileges.py
@@ -225,16 +225,6 @@ def test_analyze_privileges_skips_superuser(cursor):
     assert actual == expected
 
 
-@pytest.mark.parametrize('input, expected', [
-    ('myschema.myschema.mytable', 'myschema."myschema.mytable"'),
-    ('myschema."myschema.mytable"', 'myschema."myschema.mytable"'),
-    ('myschema.mytable', 'myschema."mytable"'),
-    ('unqualified', 'unqualified'),
-])
-def test_ensure_quoted_identifier(input, expected):
-    assert privs.ensure_quoted_identifier(input) == expected
-
-
 @pytest.mark.parametrize('object_kind', privs.PRIVILEGE_MAP.keys())
 def test_init_default_acl_possible(object_kind, mockdbcontext):
     privconf = privs.PrivilegeAnalyzer(rolename=DUMMY, access=DUMMY, object_kind=object_kind,

--- a/tests/test_spec_inspector.py
+++ b/tests/test_spec_inspector.py
@@ -79,12 +79,13 @@ def test_ensure_no_object_owned_twice(mockdbcontext):
     role1:
         owns:
             tables:
+                # Ensure function can handle some objects being quoted and some not
                 - schema1.table1
-                - schema1.table2
+                - schema1."table2"
     """
     spec = yaml.load(spec_yaml)
     errors = spec_inspector.ensure_no_object_owned_twice(spec, mockdbcontext, 'tables')
-    expected = spec_inspector.MULTIPLE_OBJKIND_OWNER_ERR_MSG.format('Table', 'schema1.table1',
+    expected = spec_inspector.MULTIPLE_OBJKIND_OWNER_ERR_MSG.format('Table', 'schema1."table1"',
                                                                     'role0, role1')
     assert [expected] == errors
 
@@ -93,9 +94,9 @@ def test_ensure_no_object_owned_twice_schema_expansion_works(mockdbcontext):
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             'schema1': {
-                'schema1.table1': {'owner': 'owner1', 'is_dependent': False},
-                'schema1.table2': {'owner': 'owner2', 'is_dependent': False},
-                'schema1.table3': {'owner': 'owner3', 'is_dependent': False},
+                'schema1."table1"': {'owner': 'owner1', 'is_dependent': False},
+                'schema1."table2"': {'owner': 'owner2', 'is_dependent': False},
+                'schema1."table3"': {'owner': 'owner3', 'is_dependent': False},
             },
         },
     }
@@ -109,28 +110,29 @@ def test_ensure_no_object_owned_twice_schema_expansion_works(mockdbcontext):
     role1:
         owns:
             tables:
-                - schema1.table1
+                # Ensure function can handle some objects being quoted and some not
+                - schema1."table1"
                 - schema1.table3
     """
     spec = yaml.load(spec_yaml)
     errors = spec_inspector.ensure_no_object_owned_twice(spec, mockdbcontext, 'tables')
     expected = set([
-        spec_inspector.MULTIPLE_OBJKIND_OWNER_ERR_MSG.format('Table', 'schema1.table1', 'role0, role1'),
-        spec_inspector.MULTIPLE_OBJKIND_OWNER_ERR_MSG.format('Table', 'schema1.table3', 'role0, role1')
+        spec_inspector.MULTIPLE_OBJKIND_OWNER_ERR_MSG.format('Table', 'schema1."table1"', 'role0, role1'),
+        spec_inspector.MULTIPLE_OBJKIND_OWNER_ERR_MSG.format('Table', 'schema1."table3"', 'role0, role1')
     ])
     assert set(errors) == expected
 
 
 def test_ensure_no_missing_objects_missing_in_db(mockdbcontext):
     mockdbcontext.get_all_raw_object_attributes = lambda: {
-        ObjectAttributes('tables', 'schema0', 'schema0.table1', 'owner1', False),
-        ObjectAttributes('tables', 'schema0', 'schema0.table3', 'owner3', False),
+        ObjectAttributes('tables', 'schema0', 'schema0."table1"', 'owner1', False),
+        ObjectAttributes('tables', 'schema0', 'schema0."table3"', 'owner3', False),
     }
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             'schema0': {
-                'schema0.table1': {'owner': 'owner1', 'is_dependent': False},
-                'schema0.table3': {'owner': 'owner3', 'is_dependent': False},
+                'schema0."table1"': {'owner': 'owner1', 'is_dependent': False},
+                'schema0."table3"': {'owner': 'owner3', 'is_dependent': False},
             },
         },
     }
@@ -138,35 +140,36 @@ def test_ensure_no_missing_objects_missing_in_db(mockdbcontext):
     role0:
         owns:
             tables:
-                - schema0.table1
-                - schema0.table2
+                # Ensure function can handle some objects being quoted and some not
+                - schema0."table1"
+                - schema0."table2"
                 - schema0.table3
                 - schema0.table4
     """
     spec = yaml.load(spec_yaml)
     errors = spec_inspector.ensure_no_missing_objects(spec, mockdbcontext, 'tables')
     expected = spec_inspector.UNKNOWN_OBJECTS_MSG.format(objkind='tables',
-                                                         unknown_objects='schema0.table2, schema0.table4')
+                                                         unknown_objects='schema0."table2", schema0."table4"')
     assert errors == [expected]
 
 
 def test_ensure_no_missing_objects_missing_in_spec(mockdbcontext):
     mockdbcontext.get_all_raw_object_attributes = lambda: {
-        ObjectAttributes('tables', 'schema0', 'schema0.table1', 'owner1', False),
-        ObjectAttributes('tables', 'schema0', 'schema0.table2', 'owner1', False),
-        ObjectAttributes('tables', 'schema0', 'schema0.table3', 'owner3', False),
-        ObjectAttributes('tables', 'schema0', 'schema0.table4', 'owner3', False),
+        ObjectAttributes('tables', 'schema0', 'schema0."table1"', 'owner1', False),
+        ObjectAttributes('tables', 'schema0', 'schema0."table2"', 'owner1', False),
+        ObjectAttributes('tables', 'schema0', 'schema0."table3"', 'owner3', False),
+        ObjectAttributes('tables', 'schema0', 'schema0."table4"', 'owner3', False),
         # This should be skipped as it is dependent
-        ObjectAttributes('tables', 'schema0', 'schema0.table5', 'owner3', True),
+        ObjectAttributes('tables', 'schema0', 'schema0."table5"', 'owner3', True),
     }
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             'schema0': {
-                'schema0.table1': {'owner': 'owner1', 'is_dependent': False},
-                'schema0.table2': {'owner': 'owner1', 'is_dependent': False},
-                'schema0.table3': {'owner': 'owner3', 'is_dependent': False},
-                'schema0.table4': {'owner': 'owner3', 'is_dependent': False},
-                'schema0.table5': {'owner': 'owner3', 'is_dependent': True},
+                'schema0."table1"': {'owner': 'owner1', 'is_dependent': False},
+                'schema0."table2"': {'owner': 'owner1', 'is_dependent': False},
+                'schema0."table3"': {'owner': 'owner3', 'is_dependent': False},
+                'schema0."table4"': {'owner': 'owner3', 'is_dependent': False},
+                'schema0."table5"': {'owner': 'owner3', 'is_dependent': True},
             },
         },
     }
@@ -174,26 +177,27 @@ def test_ensure_no_missing_objects_missing_in_spec(mockdbcontext):
     role0:
         owns:
             tables:
-                - schema0.table1
+                # Ensure function can handle some objects being quoted and some not
+                - schema0."table1"
                 - schema0.table3
     """
     spec = yaml.load(spec_yaml)
     errors = spec_inspector.ensure_no_missing_objects(spec, mockdbcontext, 'tables')
     expected = spec_inspector.UNOWNED_OBJECTS_MSG.format(objkind='tables',
-                                                         unowned_objects='schema0.table2, schema0.table4')
+                                                         unowned_objects='schema0."table2", schema0."table4"')
     assert errors == [expected]
 
 
 def test_ensure_no_missing_objects_schema_expansion_works(mockdbcontext):
     mockdbcontext.get_all_raw_object_attributes = lambda: {
-        ObjectAttributes('tables', 'schema0', 'schema0.table1', 'owner1', False),
-        ObjectAttributes('tables', 'schema0', 'schema0.table2', 'owner3', False),
+        ObjectAttributes('tables', 'schema0', 'schema0."table1"', 'owner1', False),
+        ObjectAttributes('tables', 'schema0', 'schema0."table2"', 'owner3', False),
     }
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             'schema0': {
-                'schema0.table1': {'owner': 'owner1', 'is_dependent': False},
-                'schema0.table2': {'owner': 'owner2', 'is_dependent': False},
+                'schema0."table1"': {'owner': 'owner1', 'is_dependent': False},
+                'schema0."table2"': {'owner': 'owner2', 'is_dependent': False},
             },
         },
     }
@@ -212,9 +216,9 @@ def test_ensure_no_dependent_object_is_owned(mockdbcontext):
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             'schema0': {
-                'schema0.table1': {'owner': 'owner1', 'is_dependent': False},
-                'schema0.table2': {'owner': 'owner2', 'is_dependent': True},
-                'schema0.table3': {'owner': 'owner2', 'is_dependent': True},
+                'schema0."table1"': {'owner': 'owner1', 'is_dependent': False},
+                'schema0."table2"': {'owner': 'owner2', 'is_dependent': True},
+                'schema0."table3"': {'owner': 'owner2', 'is_dependent': True},
             },
         },
     }
@@ -222,14 +226,15 @@ def test_ensure_no_dependent_object_is_owned(mockdbcontext):
     role0:
         owns:
             tables:
-                - schema0.table1
+                # Ensure function can handle some objects being quoted and some not
+                - schema0."table1"
                 - schema0.table2
                 - schema0.table3
     """
     spec = yaml.load(spec_yaml)
     errors = spec_inspector.ensure_no_dependent_object_is_owned(spec, mockdbcontext, 'tables')
     expected = spec_inspector.DEPENDENT_OBJECTS_MSG.format(objkind='tables',
-                                                           dep_objs='schema0.table2, schema0.table3')
+                                                           dep_objs='schema0."table2", schema0."table3"')
     assert errors == [expected]
 
 

--- a/tests/test_spec_inspector.py
+++ b/tests/test_spec_inspector.py
@@ -4,6 +4,7 @@ import pytest
 import yaml
 
 from pgbedrock import spec_inspector
+from pgbedrock.context import ObjectAttributes
 
 
 @pytest.fixture
@@ -15,7 +16,7 @@ def set_envvar(request):
     del os.environ[k]
 
 
-def test_verify_spec_fails_multiple_roles_own_schema(capsys):
+def test_ensure_no_schema_owned_twice():
     spec_yaml = """
     jfinance:
         owns:
@@ -28,11 +29,12 @@ def test_verify_spec_fails_multiple_roles_own_schema(capsys):
     """
     spec = yaml.load(spec_yaml)
     errors = spec_inspector.ensure_no_schema_owned_twice(spec)
-    expected = spec_inspector.MULTIPLE_SCHEMA_OWNER_ERR_MSG.format('finance_documents', 'jfinance, jfauxnance')
+    expected = spec_inspector.MULTIPLE_SCHEMA_OWNER_ERR_MSG.format('finance_documents',
+                                                                   'jfauxnance, jfinance')
     assert [expected] == errors
 
 
-def test_verify_spec_fails_multiple_roles_own_schema_personal_schema(capsys):
+def test_ensure_no_schema_owned_twice_with_personal_schemas():
     spec_yaml = """
     jfinance:
         has_personal_schema: yes
@@ -46,11 +48,213 @@ def test_verify_spec_fails_multiple_roles_own_schema_personal_schema(capsys):
     """
     spec = yaml.load(spec_yaml)
     errors = spec_inspector.ensure_no_schema_owned_twice(spec)
-    expected = spec_inspector.MULTIPLE_SCHEMA_OWNER_ERR_MSG.format('jfinance', 'jfinance, jfauxnance')
+    expected = spec_inspector.MULTIPLE_SCHEMA_OWNER_ERR_MSG.format('jfinance',
+                                                                   'jfauxnance, jfinance')
     assert [expected] == errors
 
 
-def test_verify_spec_fails_object_referenced_read_write(capsys):
+def test_ensure_no_object_owned_twice(mockdbcontext):
+    mockdbcontext.get_all_object_attributes = lambda: {}
+
+    spec_yaml = """
+    # No config
+    foo:
+
+    # Config but no 'owns'
+    bar:
+        has_personal_schema: True
+
+    # Has 'owns' but not for objkind
+    baz:
+        owns:
+            schemas:
+                - schema0
+
+    role0:
+        owns:
+            tables:
+                - schema0.table0
+                - schema1.table1
+
+    role1:
+        owns:
+            tables:
+                - schema1.table1
+                - schema1.table2
+    """
+    spec = yaml.load(spec_yaml)
+    errors = spec_inspector.ensure_no_object_owned_twice(spec, mockdbcontext, 'tables')
+    expected = spec_inspector.MULTIPLE_OBJKIND_OWNER_ERR_MSG.format('Table', 'schema1.table1',
+                                                                    'role0, role1')
+    assert [expected] == errors
+
+
+def test_ensure_no_object_owned_twice_schema_expansion_works(mockdbcontext):
+    mockdbcontext.get_all_object_attributes = lambda: {
+        'tables': {
+            'schema1': {
+                'schema1.table1': {'owner': 'owner1', 'is_dependent': False},
+                'schema1.table2': {'owner': 'owner2', 'is_dependent': False},
+                'schema1.table3': {'owner': 'owner3', 'is_dependent': False},
+            },
+        },
+    }
+    spec_yaml = """
+    role0:
+        owns:
+            tables:
+                - schema0.table0
+                - schema1.*
+
+    role1:
+        owns:
+            tables:
+                - schema1.table1
+                - schema1.table3
+    """
+    spec = yaml.load(spec_yaml)
+    errors = spec_inspector.ensure_no_object_owned_twice(spec, mockdbcontext, 'tables')
+    expected = set([
+        spec_inspector.MULTIPLE_OBJKIND_OWNER_ERR_MSG.format('Table', 'schema1.table1', 'role0, role1'),
+        spec_inspector.MULTIPLE_OBJKIND_OWNER_ERR_MSG.format('Table', 'schema1.table3', 'role0, role1')
+    ])
+    assert set(errors) == expected
+
+
+def test_ensure_no_missing_objects_missing_in_db(mockdbcontext):
+    mockdbcontext.get_all_raw_object_attributes = lambda: {
+        ObjectAttributes('tables', 'schema0', 'schema0.table1', 'owner1', False),
+        ObjectAttributes('tables', 'schema0', 'schema0.table3', 'owner3', False),
+    }
+    mockdbcontext.get_all_object_attributes = lambda: {
+        'tables': {
+            'schema0': {
+                'schema0.table1': {'owner': 'owner1', 'is_dependent': False},
+                'schema0.table3': {'owner': 'owner3', 'is_dependent': False},
+            },
+        },
+    }
+    spec_yaml = """
+    role0:
+        owns:
+            tables:
+                - schema0.table1
+                - schema0.table2
+                - schema0.table3
+                - schema0.table4
+    """
+    spec = yaml.load(spec_yaml)
+    errors = spec_inspector.ensure_no_missing_objects(spec, mockdbcontext, 'tables')
+    expected = spec_inspector.UNKNOWN_OBJECTS_MSG.format(objkind='tables',
+                                                         unknown_objects='schema0.table2, schema0.table4')
+    assert errors == [expected]
+
+
+def test_ensure_no_missing_objects_missing_in_spec(mockdbcontext):
+    mockdbcontext.get_all_raw_object_attributes = lambda: {
+        ObjectAttributes('tables', 'schema0', 'schema0.table1', 'owner1', False),
+        ObjectAttributes('tables', 'schema0', 'schema0.table2', 'owner1', False),
+        ObjectAttributes('tables', 'schema0', 'schema0.table3', 'owner3', False),
+        ObjectAttributes('tables', 'schema0', 'schema0.table4', 'owner3', False),
+        # This should be skipped as it is dependent
+        ObjectAttributes('tables', 'schema0', 'schema0.table5', 'owner3', True),
+    }
+    mockdbcontext.get_all_object_attributes = lambda: {
+        'tables': {
+            'schema0': {
+                'schema0.table1': {'owner': 'owner1', 'is_dependent': False},
+                'schema0.table2': {'owner': 'owner1', 'is_dependent': False},
+                'schema0.table3': {'owner': 'owner3', 'is_dependent': False},
+                'schema0.table4': {'owner': 'owner3', 'is_dependent': False},
+                'schema0.table5': {'owner': 'owner3', 'is_dependent': True},
+            },
+        },
+    }
+    spec_yaml = """
+    role0:
+        owns:
+            tables:
+                - schema0.table1
+                - schema0.table3
+    """
+    spec = yaml.load(spec_yaml)
+    errors = spec_inspector.ensure_no_missing_objects(spec, mockdbcontext, 'tables')
+    expected = spec_inspector.UNOWNED_OBJECTS_MSG.format(objkind='tables',
+                                                         unowned_objects='schema0.table2, schema0.table4')
+    assert errors == [expected]
+
+
+def test_ensure_no_missing_objects_schema_expansion_works(mockdbcontext):
+    mockdbcontext.get_all_raw_object_attributes = lambda: {
+        ObjectAttributes('tables', 'schema0', 'schema0.table1', 'owner1', False),
+        ObjectAttributes('tables', 'schema0', 'schema0.table2', 'owner3', False),
+    }
+    mockdbcontext.get_all_object_attributes = lambda: {
+        'tables': {
+            'schema0': {
+                'schema0.table1': {'owner': 'owner1', 'is_dependent': False},
+                'schema0.table2': {'owner': 'owner2', 'is_dependent': False},
+            },
+        },
+    }
+    spec_yaml = """
+    role0:
+        owns:
+            tables:
+                - schema0.*
+    """
+    spec = yaml.load(spec_yaml)
+    errors = spec_inspector.ensure_no_missing_objects(spec, mockdbcontext, 'tables')
+    assert errors == []
+
+
+def test_ensure_no_dependent_object_is_owned(mockdbcontext):
+    mockdbcontext.get_all_object_attributes = lambda: {
+        'tables': {
+            'schema0': {
+                'schema0.table1': {'owner': 'owner1', 'is_dependent': False},
+                'schema0.table2': {'owner': 'owner2', 'is_dependent': True},
+                'schema0.table3': {'owner': 'owner2', 'is_dependent': True},
+            },
+        },
+    }
+    spec_yaml = """
+    role0:
+        owns:
+            tables:
+                - schema0.table1
+                - schema0.table2
+                - schema0.table3
+    """
+    spec = yaml.load(spec_yaml)
+    errors = spec_inspector.ensure_no_dependent_object_is_owned(spec, mockdbcontext, 'tables')
+    expected = spec_inspector.DEPENDENT_OBJECTS_MSG.format(objkind='tables',
+                                                           dep_objs='schema0.table2, schema0.table3')
+    assert errors == [expected]
+
+
+def test_ensure_no_dependent_object_is_owned_schema_expansion_skips_deps(mockdbcontext):
+    mockdbcontext.get_all_object_attributes = lambda: {
+        'tables': {
+            'schema0': {
+                'schema0.table1': {'owner': 'owner1', 'is_dependent': False},
+                'schema0.table2': {'owner': 'owner2', 'is_dependent': True},
+                'schema0.table3': {'owner': 'owner2', 'is_dependent': True},
+            },
+        },
+    }
+    spec_yaml = """
+    role0:
+        owns:
+            tables:
+                - schema0.*
+    """
+    spec = yaml.load(spec_yaml)
+    errors = spec_inspector.ensure_no_dependent_object_is_owned(spec, mockdbcontext, 'tables')
+    assert errors == []
+
+
+def test_verify_spec_fails_object_referenced_read_write():
     spec_yaml = """
     margerie:
         can_login: true
@@ -79,7 +283,7 @@ def test_verify_spec_fails_object_referenced_read_write(capsys):
         assert [expected] == errors
 
 
-def test_verify_spec_fails_role_defined_multiple_times(tmpdir, capsys):
+def test_verify_spec_fails_role_defined_multiple_times(tmpdir):
     spec_path = tmpdir.join('spec.yml')
     spec_path.write("""
     jfinance:
@@ -101,7 +305,7 @@ def test_verify_spec_fails_role_defined_multiple_times(tmpdir, capsys):
     assert [expected] == errors
 
 
-def test_verify_spec_fails(capsys):
+def test_verify_spec_fails():
     """ We could check more functionality, but at that point we'd just be testing cerberus. This
     test is just to verify that a failure will happen and will be presented as we'd expect """
     spec_yaml = """
@@ -115,7 +319,7 @@ def test_verify_spec_fails(capsys):
     assert expected == errors[0]
 
 
-def test_verify_spec_succeeds(capsys):
+def test_verify_spec_succeeds():
     spec_yaml = """
         fred:
             attributes:


### PR DESCRIPTION
This PR addresses Issue #4 (Support table and sequence ownership).

It does so by doing 3 things:

1. Have pgbedrock generate add table and sequence ownership information into the spec that pgbedrock generates.
2. Have the spec_inspector module validate a variety of conditions that are necessary in order for us to manage ownerships: that a spec has no objects with multiple owners, has no objects with no owners, has no auto-dependent objects listed with owners, and has no objects in the spec that are not in the database. This allows pgbedrock configure to run without having to check a ton of edge cases while it executes.
3. Have pgbedrock configure manage table and sequence ownership.

I have added tests to validate that the above 3 items work as expected and have also verified that doing `pgbedrock generate` followed by `pgbedrock configure` both runs on our staging database and that it shows no changes.

I know that this PR is kind of large and painful: these 3 things all depend upon each other, so they need to all be merged into master concurrently. Ideally this might have been a feature branch with 3 separate PRs added to it. That didn't happen though, so if there's any way I can make this less painful to read through let me know.