### PR TITLE
Convert dashes to underscores in password envvars

### DIFF
--- a/pgbedrock/core_generate.py
+++ b/pgbedrock/core_generate.py
@@ -382,9 +382,11 @@ def nondefault_attributes_as_list(rolename, nondefaults):
         elif attr == 'rolconnlimit':
             results.append('CONNECTION LIMIT {}'.format(val))
         elif attr == 'rolpassword':
-            # We put a templated environment variable here instead of
-            # rolpassword's val (which is just an md5 hash anyway)
-            results.append('PASSWORD "{{{{ env[\'{}_PASSWORD\'] }}}}"'.format(rolename.upper()))
+            # Use underscores since tools like Bamboo do not like dashes in envvar names
+            envvar_rolename = rolename.replace('-', '_').upper()
+            # We put a templated environment variable here instead of rolpassword's val
+            # (which is just an md5 hash anyway)
+            results.append('PASSWORD "{{{{ env[\'{}_PASSWORD\'] }}}}"'.format(envvar_rolename))
         else:
             keyword = COLUMN_NAME_TO_KEYWORD[attr]
             prefix = '' if val else 'NO'

--- a/tests/test_core_generate.py
+++ b/tests/test_core_generate.py
@@ -66,6 +66,28 @@ def test_add_attributes(mockdbcontext):
     assert set(actual['bar']['attributes']) == set(expected['bar']['attributes'])
 
 
+def test_add_attributes_password_for_rolename_with_dash(mockdbcontext):
+    mockdbcontext.get_all_role_attributes = lambda: {
+        'foo-bar-baz': {
+            'rolpassword': 'supersecret',
+            # These are expected to exist for core_generate.add_attributes
+            'rolcanlogin': False,
+            'rolsuper': False,
+        },
+    }
+    expected = {
+        'foo-bar-baz': {
+            'attributes': [
+                'PASSWORD "{{ env[\'FOO_BAR_BAZ_PASSWORD\'] }}"',
+            ],
+        },
+    }
+    spec = {'foo-bar-baz': {}}
+    actual = core_generate.add_attributes(spec, mockdbcontext)
+
+    assert actual == expected
+
+
 def test_add_memberships(mockdbcontext):
     mockdbcontext.get_all_memberships = lambda: [
         ('foo', 'bar'),


### PR DESCRIPTION
Tools like Bamboo do not like dashes in envvar names. As a result, it
becomes difficult to use these tools with pgbedrock if your role names
have dashes. This commit changes dashes in password envvars to
underscores, e.g. the role foo-bar would have password envvar
FOO_BAR_PASSWORD instead of FOO-BAR_PASSWORD