### PR TITLE
Parametrize Travis Builds so Environments are Comparable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 services:
   - docker
 
+env:
+  - SUPPORTED_PG_VERSIONS=9.3.23
+  - SUPPORTED_PG_VERSIONS=9.4.18
+  - SUPPORTED_PG_VERSIONS=9.5.13
+  - SUPPORTED_PG_VERSIONS=9.6.4
+  - SUPPORTED_PG_VERSIONS=10.4
+
 script:
   # sudo is required in order to run `make clean`
   - sudo make test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: attach build build_tester clean coverage create_network psql release_pypi release_pypitest release_quay remove_network start_postgres stop_postgres test test_one_pg_version test27 test36 wait_for_postgres
 
-SUPPORTED_PG_VERSIONS= 9.5.13 9.6.4
+SUPPORTED_PG_VERSIONS ?= 9.3.23 9.4.18 9.5.13 9.6.4 10.4
 # The default Postgres that will be used in individual targets
 POSTGRES_VERSION = 9.6.4
 


### PR DESCRIPTION
This is a PR against a PR, @zcmarine 's in-progress PR to add multiple postgres support.

I have changed it to leverage Travis's ability to run a build matrix and parametrize the test suite against different environments and run each build separately -- both for parallelization and for ease of tracking what environment is broken versus having a monolithic test suite that controls environmental conditions.

Now we can see on Travis what part of the build is failing from a high-level view:

![image](https://user-images.githubusercontent.com/160099/40151257-c817c642-594c-11e8-997d-220f45d38417.png)
