### PR TITLE
Add ObjectName class for representing myschema.myobject references

### DIFF
--- a/pgbedrock/common.py
+++ b/pgbedrock/common.py
@@ -107,7 +107,6 @@ class ObjectName(object):
         if self._unqualified_name and self._unqualified_name == '*':
             self._qualified_name = '{}.{}'.format(self.schema, self.unqualified_name)
         elif self._unqualified_name and self._unqualified_name != '*':
-            #TODO: Change these to "schema"."table" after converting pgbedrock to use this class
             # Note that if we decide to support "schema"."table" within YAML that we'll need to
             # add a custom constructor since otherwise YAML gets confused unless you do
             # '"schema"."table"'
@@ -139,10 +138,6 @@ class ObjectName(object):
         stripped, but note that we don't do anything with impossible input like 'foo."bar".baz'
         (which is impossible because the object name would include double quotes in it). Instead,
         we let processing proceed and the issue bubble up downstream.
-
-        #TODO: add spec validation to prevent things like the impossible situation above, then
-        amend this docstring to note that.
-
         """
         if '.' not in text:
             return cls(schema=text)
@@ -152,6 +147,10 @@ class ObjectName(object):
         schema, unqualified_name = text.split('.', 1)
         # Don't worry about removing double quotes as that happens in __init__
         return cls(schema=schema, unqualified_name=unqualified_name)
+
+    def only_schema(self):
+        """ Return an ObjectName instance for the schema associated with the current object """
+        return ObjectName(self.schema)
 
     @property
     def schema(self):

--- a/pgbedrock/common.py
+++ b/pgbedrock/common.py
@@ -28,28 +28,6 @@ def check_name(name):
         return name
 
 
-def ensure_quoted_identifier(objname):
-    """
-    Ensure that all parts of an identifier after the first dot are surrounded by double quotes.
-    This is necessary because Postgres will not accept identifiers with more than one dot in them
-    unless they are constructed like this.
-
-    How do identifiers like this come to be in the first place? A common scenario is someone
-    accidentally creating an object like 'myschema.mytable' _within_ a schema, i.e. the
-    schema-qualified object is myschema.myschema.mytable. Postgres won't accept a name like
-    that, but it will accept myschema."myschema.mytable".
-    """
-    # This function is irrelevant if the object isn't schema-qualified
-    if '.' not in objname:
-        return objname
-
-    schema, nonschema = objname.split('.', 1)
-    if nonschema.startswith('"') and nonschema.endswith('"'):
-        return objname
-
-    return '{}."{}"'.format(schema, nonschema)
-
-
 def fail(msg):
     click.secho(msg, fg='red')
     sys.exit(1)

--- a/pgbedrock/common.py
+++ b/pgbedrock/common.py
@@ -121,6 +121,12 @@ class ObjectName(object):
     def __lt__(self, other):
         return self.qualified_name < other.qualified_name
 
+    def __repr__(self):
+        if self.unqualified_name:
+            return "ObjectName('{}', '{}')".format(self.schema, self.unqualified_name)
+
+        return "ObjectName('{}')".format(self.schema)
+
     @classmethod
     def from_str(cls, text):
         """ Convert a text representation of a qualified object name into an ObjectName instance

--- a/pgbedrock/common.py
+++ b/pgbedrock/common.py
@@ -108,6 +108,9 @@ class ObjectName(object):
             self._qualified_name = '{}.{}'.format(self.schema, self.unqualified_name)
         elif self._unqualified_name and self._unqualified_name != '*':
             #TODO: Change these to "schema"."table" after converting pgbedrock to use this class
+            # Note that if we decide to support "schema"."table" within YAML that we'll need to
+            # add a custom constructor since otherwise YAML gets confused unless you do
+            # '"schema"."table"'
             self._qualified_name = '{}."{}"'.format(self.schema, self.unqualified_name)
         else:
             self._qualified_name = '{}'.format(self.schema)

--- a/pgbedrock/common.py
+++ b/pgbedrock/common.py
@@ -98,22 +98,22 @@ class ObjectName(object):
         * Be sure that when we get the fully-qualified name it will be double quoted
             properly, i.e.  "myschema"."mytable"
     """
-    def __init__(self, schema, object_name=None):
+    def __init__(self, schema, unqualified_name=None):
         # Make sure schema and table are both stored without double quotes around
         # them; we add these when ObjectName.qualified_name is called
         self._schema = self._unquoted_item(schema)
-        self._object_name = self._unquoted_item(object_name)
+        self._unqualified_name = self._unquoted_item(unqualified_name)
 
-        if self._object_name and self._object_name == '*':
-            self._qualified_name = '{}.{}'.format(self.schema, self.object_name)
-        elif self._object_name and self._object_name != '*':
+        if self._unqualified_name and self._unqualified_name == '*':
+            self._qualified_name = '{}.{}'.format(self.schema, self.unqualified_name)
+        elif self._unqualified_name and self._unqualified_name != '*':
             #TODO: Change these to "schema"."table" after converting pgbedrock to use this class
-            self._qualified_name = '{}."{}"'.format(self.schema, self.object_name)
+            self._qualified_name = '{}."{}"'.format(self.schema, self.unqualified_name)
         else:
             self._qualified_name = '{}'.format(self.schema)
 
     def __eq__(self, other):
-        return (self.schema == other.schema) and (self.object_name == other.object_name)
+        return (self.schema == other.schema) and (self.unqualified_name == other.unqualified_name)
 
     def __hash__(self):
         return hash(self.qualified_name)
@@ -140,17 +140,17 @@ class ObjectName(object):
 
         # If there are multiple periods we assume that the first one delineates the schema from
         # the rest of the object, i.e. foo.bar.baz means schema foo and object "bar.baz"
-        schema, object_name = text.split('.', 1)
+        schema, unqualified_name = text.split('.', 1)
         # Don't worry about removing double quotes as that happens in __init__
-        return cls(schema=schema, object_name=object_name)
+        return cls(schema=schema, unqualified_name=unqualified_name)
 
     @property
     def schema(self):
         return self._schema
 
     @property
-    def object_name(self):
-        return self._object_name
+    def unqualified_name(self):
+        return self._unqualified_name
 
     @property
     def qualified_name(self):

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -233,7 +233,7 @@ PRIVILEGE_MAP = {
          },
 }
 
-ObjectInfo = namedtuple('ObjectInfo', ['kind', 'name', 'owner', 'is_dependent'])
+ObjectInfo = namedtuple('ObjectInfo', ['kind', 'dbobject', 'owner', 'is_dependent'])
 ObjectAttributes = namedtuple('ObjectAttributes',
                               ['kind', 'schema', 'dbobject', 'owner', 'is_dependent'])
 VersionInfo = namedtuple('VersionInfo', ['postgres_version', 'redshift_version', 'is_redshift'])
@@ -581,7 +581,7 @@ class DatabaseContext(object):
     def get_all_nonschema_objects_and_owners(self):
         """
         For all objkinds other than schemas return a dict of the form
-            {schema_name: [(objkind, objname, objowner, is_dependent), ...]}
+            {schema_name: [(objkind, dbobject, objowner, is_dependent), ...]}
 
         This is primarily a helper for DatabaseContext.get_schema_objects so we have O(1)
         schema object lookups instead of needing to iterate through all objects every time
@@ -589,7 +589,7 @@ class DatabaseContext(object):
         schema_objects = defaultdict(list)
         for row in self.get_all_raw_object_attributes():
             if row.kind != 'schemas':
-                objinfo = ObjectInfo(row.kind, row.dbobject.qualified_name, row.owner, row.is_dependent)
+                objinfo = ObjectInfo(row.kind, row.dbobject, row.owner, row.is_dependent)
                 schema_objects[row.schema].append(objinfo)
 
         return schema_objects

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -422,11 +422,7 @@ class DatabaseContext(object):
             set: A set of context.DBObject instances
         """
         objects_with_access = self.get_role_current_nondefaults(rolename, object_kind, access)
-
-        results = set()
-        for objname, _ in objects_with_access:
-            if objname.schema == schema:
-                results.add(objname)
+        results = set([dbo for dbo, _ in objects_with_access if dbo.schema == schema])
         return results
 
     def get_all_current_nondefaults(self):

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -455,10 +455,7 @@ class DatabaseContext(object):
             is_read_priv = row.privilege in PRIVILEGE_MAP[row.objkind]['read']
             access_key = 'read' if is_read_priv else 'write'
 
-            dbobject = DBObject(schema=row.schema, object_name=row.objname)
-            entry = (dbobject, row.privilege)
             role_nondefaults = current_nondefaults[row.grantee]
-
             # Create this role's dict substructure for the first entry we come across
             if row.objkind not in role_nondefaults:
                 role_nondefaults[row.objkind] = {
@@ -466,6 +463,8 @@ class DatabaseContext(object):
                     'write': set(),
                 }
 
+            dbobject = DBObject(schema=row.schema, object_name=row.objname)
+            entry = (dbobject, row.privilege)
             role_nondefaults[row.objkind][access_key].add(entry)
 
         return current_nondefaults

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -430,11 +430,11 @@ class DatabaseContext(object):
             {roleA: {
                 objkindA: {
                     'read': set([
-                        (objname, privilege),
+                        (dbobject, privilege),
                         ...
                         ]),
                     'write': set([
-                        (objname, privilege),
+                        (dbobject, privilege),
                         ...
                         ]),
                     },
@@ -456,7 +456,7 @@ class DatabaseContext(object):
             access_key = 'read' if is_read_priv else 'write'
 
             dbobject = DBObject(schema=row.schema, object_name=row.objname)
-            entry = (dbobject.qualified_name, row.privilege)
+            entry = (dbobject, row.privilege)
             role_nondefaults = current_nondefaults[row.grantee]
 
             # Create this role's dict substructure for the first entry we come across
@@ -477,7 +477,8 @@ class DatabaseContext(object):
         Returns a set of tuples of the form set([(objname, privilege), ... ]) """
         all_current_nondefaults = self.get_all_current_nondefaults()
         try:
-            return all_current_nondefaults[rolename][object_kind][access]
+            items = all_current_nondefaults[rolename][object_kind][access]
+            return set([(dbobject.qualified_name, priv) for dbobject, priv in items])
         except KeyError:
             return set()
 

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -238,6 +238,75 @@ ObjectAttributes = namedtuple('ObjectAttributes',
 VersionInfo = namedtuple('VersionInfo', ['postgres_version', 'redshift_version', 'is_redshift'])
 
 
+class DBObject(object):
+    """ Hold references to a specifc object, i.e. the schema and object name.
+
+    We do this in order to:
+        * Enable us to easily pick out the schema and object name for an object
+        * Be sure that when we use a schema or object name we won't have to worry
+            about existing double-quoting of these characteristics
+        * Be sure that when we get the fully-qualified name it will be double quoted
+            properly, i.e.  "myschema"."mytable"
+    """
+    def __init__(self, schema, object_name=None):
+        # Make sure schema and table are both stored without double quotes around
+        # them; we add these when DBObject.qualified_name is called
+        self._schema = self._unquoted_item(schema)
+        self._object_name = self._unquoted_item(object_name)
+
+        if self._object_name:
+            self._qualified_name = '"{}"."{}"'.format(self.schema, self.object_name)
+        else:
+            self._qualified_name = '"{}"'.format(self.schema)
+
+    def __eq__(self, other):
+        return (self.schema == other.schema) and (self.object_name == other.object_name)
+
+    def __hash__(self):
+        return hash(self.qualified_name)
+
+    @classmethod
+    def from_str(cls, text):
+        """ Convert a text representation of a qualified object name into an DBObject instance
+
+        For example, 'foo.bar', '"foo".bar', '"foo"."bar"', etc. will be converted an object with
+        schema 'foo' and object name 'bar'. Double quotes around the schema or object name are
+        stripped, but note that we don't do anything with impossible input like 'foo."bar".baz'
+        (which is impossible because the object name would include double quotes in it). Instead,
+        we let processing proceed and the issue bubble up downstream.
+
+        #TODO: add spec validation to prevent things like the impossible situation above, then
+        amend this docstring to note that.
+
+        """
+        if '.' not in text:
+            return cls(schema=text)
+
+        # If there are multiple periods we assume that the first one delineates the schema from
+        # the rest of the object, i.e. foo.bar.baz means schema foo and object "bar.baz"
+        schema, object_name = text.split('.', 1)
+        # Don't worry about removing double quotes as that happens in __init__
+        return cls(schema=schema, object_name=object_name)
+
+    @property
+    def schema(self):
+        return self._schema
+
+    @property
+    def object_name(self):
+        return self._object_name
+
+    @property
+    def qualified_name(self):
+        return self._qualified_name
+
+    @staticmethod
+    def _unquoted_item(item):
+        if item and item.startswith('"') and item.endswith('"'):
+            return item[1:-1]
+        return item
+
+
 class DatabaseContext(object):
     """ Show the current state of the database we are connected to. If the relevant information
     has not already been fetched, fetch it (this is implemented via __getattribute__ below) """

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -540,8 +540,15 @@ class DatabaseContext(object):
         return schema_objects
 
     def get_schema_objects(self, schema):
+        """
+        Args:
+            schema (common.ObjectName): The schema to get object for
+
+        Returns:
+            list
+        """
         all_objects_and_owners = self.get_all_nonschema_objects_and_owners()
-        return all_objects_and_owners.get(schema, [])
+        return all_objects_and_owners.get(schema.qualified_name, [])
 
     def is_schema_empty(self, schema, object_kind):
         """ Determine if the schema is empty with regard to the object kind specified """

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -255,9 +255,10 @@ class DBObject(object):
         self._object_name = self._unquoted_item(object_name)
 
         if self._object_name:
-            self._qualified_name = '"{}"."{}"'.format(self.schema, self.object_name)
+            #TODO: Change these to "schema"."table" after converting pgbedrock to use this class
+            self._qualified_name = '{}."{}"'.format(self.schema, self.object_name)
         else:
-            self._qualified_name = '"{}"'.format(self.schema)
+            self._qualified_name = '{}'.format(self.schema)
 
     def __eq__(self, other):
         return (self.schema == other.schema) and (self.object_name == other.object_name)

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -511,8 +511,7 @@ class DatabaseContext(object):
         for i in self.cursor.fetchall():
             row = NamedRow(*i)
             dbobject = DBObject(schema=row.schema, object_name=row.objname)
-            entry = ObjectAttributes(row.kind, row.schema, dbobject.qualified_name,
-                                     row.owner, row.is_dependent)
+            entry = ObjectAttributes(row.kind, row.schema, dbobject, row.owner, row.is_dependent)
             results.append(entry)
         return results
 
@@ -546,8 +545,8 @@ class DatabaseContext(object):
             if row.schema not in objkind_owners:
                 objkind_owners[row.schema] = dict()
 
-            objkind_owners[row.schema][row.name] = {'owner': row.owner,
-                                                    'is_dependent': row.is_dependent}
+            objkind_owners[row.schema][row.name.qualified_name] = {'owner': row.owner,
+                                                                   'is_dependent': row.is_dependent}
 
         return all_object_owners
 
@@ -589,7 +588,7 @@ class DatabaseContext(object):
         schema_objects = defaultdict(list)
         for row in self.get_all_raw_object_attributes():
             if row.kind != 'schemas':
-                objinfo = ObjectInfo(row.kind, row.name, row.owner, row.is_dependent)
+                objinfo = ObjectInfo(row.kind, row.name.qualified_name, row.owner, row.is_dependent)
                 schema_objects[row.schema].append(objinfo)
 
         return schema_objects

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -421,8 +421,8 @@ class DatabaseContext(object):
 
         results = set()
         for objname, _ in objects_with_access:
-            if objname.split('.', 1)[0] == schema:
-                results.add(objname)
+            if objname.schema == schema:
+                results.add(objname.qualified_name)
         return results
 
     def get_all_current_nondefaults(self):
@@ -474,11 +474,13 @@ class DatabaseContext(object):
         """ Return the current non-default privileges for a specific
         rolename x object_kind x access type, e.g. for role jdoe x tables x read.
 
-        Returns a set of tuples of the form set([(objname, privilege), ... ]) """
+        Returns:
+            set: A set of tuples consisting of a database object and a privilege
+                with types (context.DBObject, str)
+        """
         all_current_nondefaults = self.get_all_current_nondefaults()
         try:
-            items = all_current_nondefaults[rolename][object_kind][access]
-            return set([(dbobject.qualified_name, priv) for dbobject, priv in items])
+            return all_current_nondefaults[rolename][object_kind][access]
         except KeyError:
             return set()
 

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -255,7 +255,9 @@ class DBObject(object):
         self._schema = self._unquoted_item(schema)
         self._object_name = self._unquoted_item(object_name)
 
-        if self._object_name:
+        if self._object_name and self._object_name == '*':
+            self._qualified_name = '{}.{}'.format(self.schema, self.object_name)
+        elif self._object_name and self._object_name != '*':
             #TODO: Change these to "schema"."table" after converting pgbedrock to use this class
             self._qualified_name = '{}."{}"'.format(self.schema, self.object_name)
         else:

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -385,16 +385,16 @@ class DatabaseContext(object):
             access_key = 'read' if is_read_priv else 'write'
 
             entry = (row.objname, row.privilege)
-            role_defaults = current_nondefaults[row.grantee]
+            role_nondefaults = current_nondefaults[row.grantee]
 
             # Create this role's dict substructure for the first entry we come across
-            if row.objkind not in role_defaults:
-                role_defaults[row.objkind] = {
+            if row.objkind not in role_nondefaults:
+                role_nondefaults[row.objkind] = {
                     'read': set(),
                     'write': set(),
                 }
 
-            role_defaults[row.objkind][access_key].add(entry)
+            role_nondefaults[row.objkind][access_key].add(entry)
 
         return current_nondefaults
 

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -393,7 +393,7 @@ class DatabaseContext(object):
                     'write': set(),
                 }
 
-            objname = common.ObjectName(schema=row.schema, object_name=row.unqualified_name)
+            objname = common.ObjectName(schema=row.schema, unqualified_name=row.unqualified_name)
             entry = (objname, row.privilege)
             role_nondefaults[row.objkind][access_key].add(entry)
 
@@ -439,7 +439,7 @@ class DatabaseContext(object):
         NamedRow = namedtuple('NamedRow', ['kind', 'schema', 'unqualified_name', 'owner', 'is_dependent'])
         for i in self.cursor.fetchall():
             row = NamedRow(*i)
-            objname = common.ObjectName(schema=row.schema, object_name=row.unqualified_name)
+            objname = common.ObjectName(schema=row.schema, unqualified_name=row.unqualified_name)
             entry = ObjectAttributes(row.kind, row.schema, objname, row.owner, row.is_dependent)
             results.append(entry)
         return results

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -572,9 +572,13 @@ class DatabaseContext(object):
         return role_memberships
 
     def get_all_personal_schemas(self):
-        """ Return all personal schemas as a set """
+        """ Return all personal schemas
+
+        Returns:
+            set: A set of DBObject instances
+        """
         common.run_query(self.cursor, self.verbose, Q_GET_ALL_PERSONAL_SCHEMAS)
-        personal_schemas = set([i[0] for i in self.cursor.fetchall()])
+        personal_schemas = set([DBObject(schema=row[0]) for row in self.cursor.fetchall()])
         return personal_schemas
 
     def get_all_nonschema_objects_and_owners(self):

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -335,12 +335,11 @@ class DatabaseContext(object):
             return set()
 
     def has_default_privilege(self, rolename, schema, object_kind, access):
-        #TODO: Convert this to use ObjectName instances
         write_defaults = self.get_role_current_defaults(rolename, object_kind, access)
         for grantor, objname, priv in write_defaults:
             # So long as at least one default privilege exists in this schema and was not granted
             # by this role we consider the role to have default privileges in that schema
-            if objname.qualified_name == schema and grantor != rolename:
+            if objname == schema and grantor != rolename:
                 return True
 
         return False

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -555,15 +555,26 @@ class DatabaseContext(object):
         return self.cursor.fetchall()
 
     def get_all_schemas_and_owners(self):
-        """ Return a dict of {schema_name: schema_owner} """
+        """
+        Returns:
+            dict: a dict of {schema_name: schema_owner}, where schema_name is a context.DBObject
+        """
         all_object_owners = self.get_all_object_attributes()
         schemas_subdict = all_object_owners.get('schemas', {})
         schema_owners = dict()
         for schema, attributes in schemas_subdict.items():
-            schema_owners[schema] = attributes[DBObject(schema)]['owner']
+            dbobject = DBObject(schema)
+            schema_owners[dbobject] = attributes[dbobject]['owner']
         return schema_owners
 
     def get_schema_owner(self, schema):
+        """
+        Args:
+            schema (DBObject): The schema to find the owner for
+
+        Returns:
+            str
+        """
         all_schemas_and_owners = self.get_all_schemas_and_owners()
         return all_schemas_and_owners.get(schema)
 

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -286,11 +286,11 @@ class DatabaseContext(object):
             {roleA: {
                 objkindA: {
                     'read': set([
-                        (grantor, nspname, privilege),
+                        (grantor, ObjectName(nspname), privilege),
                         ...
                         ]),
                     'write': set([
-                        (grantor, nspname, privilege),
+                        (grantor, ObjectName(nspname), privilege),
                         ...
                         ])
                     },
@@ -311,7 +311,7 @@ class DatabaseContext(object):
             is_read_priv = row.privilege in PRIVILEGE_MAP[row.objkind]['read']
             access_key = 'read' if is_read_priv else 'write'
 
-            entry = (row.grantor, row.schema, row.privilege)
+            entry = (row.grantor, common.ObjectName(row.schema), row.privilege)
             role_defaults = current_defaults[row.grantee]
 
             # Create this role's dict substructure for the first entry we come across
@@ -335,11 +335,12 @@ class DatabaseContext(object):
             return set()
 
     def has_default_privilege(self, rolename, schema, object_kind, access):
+        #TODO: Convert this to use ObjectName instances
         write_defaults = self.get_role_current_defaults(rolename, object_kind, access)
-        for grantor, nspname, priv in write_defaults:
+        for grantor, objname, priv in write_defaults:
             # So long as at least one default privilege exists in this schema and was not granted
             # by this role we consider the role to have default privileges in that schema
-            if nspname == schema and grantor != rolename:
+            if objname.qualified_name == schema and grantor != rolename:
                 return True
 
         return False

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -518,11 +518,11 @@ class DatabaseContext(object):
         """ Return a dict of the form:
             {objkindA: {
                 'schemaA': {
-                    'objnameA': {
+                    'dbobjectA': {
                         'owner': ownerA,
                         'is_dependent': False,
                         },
-                    'objnameB': {
+                    'dbobjectB': {
                         'owner': ownerB,
                         'is_dependent': True,
                         },
@@ -544,9 +544,8 @@ class DatabaseContext(object):
             if row.schema not in objkind_owners:
                 objkind_owners[row.schema] = dict()
 
-            # TODO: Remove this qualified_name
-            objkind_owners[row.schema][row.dbobject.qualified_name] = {'owner': row.owner,
-                                                                       'is_dependent': row.is_dependent}
+            objkind_owners[row.schema][row.dbobject] = {'owner': row.owner,
+                                                        'is_dependent': row.is_dependent}
 
         return all_object_owners
 
@@ -559,7 +558,9 @@ class DatabaseContext(object):
         """ Return a dict of {schema_name: schema_owner} """
         all_object_owners = self.get_all_object_attributes()
         schemas_subdict = all_object_owners.get('schemas', {})
-        schema_owners = {k: v[k]['owner'] for k, v in schemas_subdict.items()}
+        schema_owners = dict()
+        for schema, attributes in schemas_subdict.items():
+            schema_owners[schema] = attributes[DBObject(schema)]['owner']
         return schema_owners
 
     def get_schema_owner(self, schema):

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -352,7 +352,7 @@ class DatabaseContext(object):
             set: A set of common.ObjectName instances
         """
         objects_with_access = self.get_role_current_nondefaults(rolename, object_kind, access)
-        results = set([objname for objname, _ in objects_with_access if objname.schema == schema])
+        results = set([objname for objname, _ in objects_with_access if objname.only_schema() == schema])
         return results
 
     def get_all_current_nondefaults(self):

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -416,13 +416,17 @@ class DatabaseContext(object):
 
     def get_role_objects_with_access(self, rolename, schema, object_kind, access):
         """ Return the set of objects in this schema which the given rolename has the
-        specified access for """
+        specified access for
+
+        Returns:
+            set: A set of context.DBObject instances
+        """
         objects_with_access = self.get_role_current_nondefaults(rolename, object_kind, access)
 
         results = set()
         for objname, _ in objects_with_access:
             if objname.schema == schema:
-                results.add(objname.qualified_name)
+                results.add(objname)
         return results
 
     def get_all_current_nondefaults(self):

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -269,6 +269,9 @@ class DBObject(object):
     def __hash__(self):
         return hash(self.qualified_name)
 
+    def __lt__(self, other):
+        return self.qualified_name < other.qualified_name
+
     @classmethod
     def from_str(cls, text):
         """ Convert a text representation of a qualified object name into an DBObject instance

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -371,13 +371,13 @@ class DatabaseContext(object):
 
             This will not include privileges granted by this role to itself
         """
-        DefaultRow = namedtuple('DefaultRow',
-                                ['grantee', 'objkind', 'grantor', 'schema', 'privilege'])
+        NamedRow = namedtuple('NamedRow',
+                              ['grantee', 'objkind', 'grantor', 'schema', 'privilege'])
         common.run_query(self.cursor, self.verbose, Q_GET_ALL_CURRENT_DEFAULTS)
 
         current_defaults = defaultdict(dict)
         for i in self.cursor.fetchall():
-            row = DefaultRow(*i)
+            row = NamedRow(*i)
             is_read_priv = row.privilege in PRIVILEGE_MAP[row.objkind]['read']
             access_key = 'read' if is_read_priv else 'write'
 

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -235,7 +235,7 @@ PRIVILEGE_MAP = {
 
 ObjectInfo = namedtuple('ObjectInfo', ['kind', 'name', 'owner', 'is_dependent'])
 ObjectAttributes = namedtuple('ObjectAttributes',
-                              ['kind', 'schema', 'name', 'owner', 'is_dependent'])
+                              ['kind', 'schema', 'dbobject', 'owner', 'is_dependent'])
 VersionInfo = namedtuple('VersionInfo', ['postgres_version', 'redshift_version', 'is_redshift'])
 
 
@@ -545,8 +545,9 @@ class DatabaseContext(object):
             if row.schema not in objkind_owners:
                 objkind_owners[row.schema] = dict()
 
-            objkind_owners[row.schema][row.name.qualified_name] = {'owner': row.owner,
-                                                                   'is_dependent': row.is_dependent}
+            # TODO: Remove this qualified_name
+            objkind_owners[row.schema][row.dbobject.qualified_name] = {'owner': row.owner,
+                                                                       'is_dependent': row.is_dependent}
 
         return all_object_owners
 
@@ -588,7 +589,7 @@ class DatabaseContext(object):
         schema_objects = defaultdict(list)
         for row in self.get_all_raw_object_attributes():
             if row.kind != 'schemas':
-                objinfo = ObjectInfo(row.kind, row.name.qualified_name, row.owner, row.is_dependent)
+                objinfo = ObjectInfo(row.kind, row.dbobject.qualified_name, row.owner, row.is_dependent)
                 schema_objects[row.schema].append(objinfo)
 
         return schema_objects

--- a/pgbedrock/core_generate.py
+++ b/pgbedrock/core_generate.py
@@ -131,7 +131,7 @@ def add_nonschema_ownerships(spec, dbcontext, objkind):
             elif objkind not in spec[owner]['owns']:
                 spec[owner]['owns'][objkind] = []
 
-            objname = common.ObjectName(schema=schema, object_name='*')
+            objname = common.ObjectName(schema=schema, unqualified_name='*')
             spec[owner]['owns'][objkind].append(objname)
 
             # Since all objects in this schema are owned by one role, we can skip the below
@@ -211,7 +211,7 @@ def collapse_personal_schemas(role, objects, objkind, dbcontext):
     """
     personal_schemas = dbcontext.get_all_personal_schemas()
     personal_schemas_star = set([
-        common.ObjectName(schema=objname.schema, object_name='*') for objname in personal_schemas
+        common.ObjectName(schema=objname.schema, unqualified_name='*') for objname in personal_schemas
     ])
 
     if not personal_schemas_star:
@@ -220,11 +220,11 @@ def collapse_personal_schemas(role, objects, objkind, dbcontext):
     non_empty_personal_schemas = set()
     for objname in personal_schemas:
         if objname.schema != role and not dbcontext.is_schema_empty(objname.schema, objkind):
-            non_empty_personal_schemas.add(common.ObjectName(schema=objname.schema, object_name='*'))
+            non_empty_personal_schemas.add(common.ObjectName(schema=objname.schema, unqualified_name='*'))
 
     if non_empty_personal_schemas.difference(objects) == set():
         objects.difference_update(personal_schemas_star)
-        objects.add(common.ObjectName(schema='personal_schemas', object_name='*'))
+        objects.add(common.ObjectName(schema='personal_schemas', unqualified_name='*'))
 
     return objects
 
@@ -364,7 +364,7 @@ def determine_nonschema_privileges_for_schema(role, objkind, objname, dbcontext)
     if has_default_write or (all_writes == schema_objects and all_writes != set()):
         # In the second condition, every object has a write privilege, so we assume that means
         # that this role should have default write privileges
-        return set([common.ObjectName(schema=objname.schema, object_name='*')]), set()
+        return set([common.ObjectName(schema=objname.schema, unqualified_name='*')]), set()
 
     # If we haven't returned yet then no write default privilege exists; we will have to
     # grant each write individually, meaning we also need to look at read privileges
@@ -374,7 +374,7 @@ def determine_nonschema_privileges_for_schema(role, objkind, objname, dbcontext)
     if has_default_read or (all_reads == schema_objects and all_reads != set()):
         # In the second condition, every object has a read privilege, so we assume that means
         # that this role should have default read privileges
-        return all_writes, set([common.ObjectName(schema=objname.schema, object_name='*')])
+        return all_writes, set([common.ObjectName(schema=objname.schema, unqualified_name='*')])
     else:
         # We have to grant each read individually as well. Because a write will already grant
         # a read, we have to remove all write-granted objects from our read grants

--- a/pgbedrock/core_generate.py
+++ b/pgbedrock/core_generate.py
@@ -352,7 +352,7 @@ def determine_nonschema_privileges_for_schema(role, objkind, objname, dbcontext)
             privileges and a set of common.ObjectName instances with read privileges
     """
     # Get all objects of this objkind in this schema and which are not owned by this role
-    objects_and_owners = dbcontext.get_schema_objects(objname.schema)
+    objects_and_owners = dbcontext.get_schema_objects(objname)
     schema_objects = set()
     for entry in objects_and_owners:
         if entry.kind == objkind and entry.owner != role:

--- a/pgbedrock/core_generate.py
+++ b/pgbedrock/core_generate.py
@@ -359,8 +359,7 @@ def determine_nonschema_privileges_for_schema(role, objkind, objname, dbcontext)
             schema_objects.add(entry.objname)
 
     has_default_write = dbcontext.has_default_privilege(role, objname, objkind, 'write')
-    # TODO: Convert the below to use ObjectNames
-    all_writes = dbcontext.get_role_objects_with_access(role, objname.schema, objkind, 'write')
+    all_writes = dbcontext.get_role_objects_with_access(role, objname, objkind, 'write')
 
     if has_default_write or (all_writes == schema_objects and all_writes != set()):
         # In the second condition, every object has a write privilege, so we assume that means
@@ -370,7 +369,7 @@ def determine_nonschema_privileges_for_schema(role, objkind, objname, dbcontext)
     # If we haven't returned yet then no write default privilege exists; we will have to
     # grant each write individually, meaning we also need to look at read privileges
     has_default_read = dbcontext.has_default_privilege(role, objname, objkind, 'read')
-    all_reads = dbcontext.get_role_objects_with_access(role, objname.schema, objkind, 'read')
+    all_reads = dbcontext.get_role_objects_with_access(role, objname, objkind, 'read')
 
     if has_default_read or (all_reads == schema_objects and all_reads != set()):
         # In the second condition, every object has a read privilege, so we assume that means
@@ -447,7 +446,6 @@ def output_spec(spec):
 
     def represent_objname(dumper, data):
         return dumper.represent_scalar('tag:yaml.org,2002:str', data.qualified_name)
-        # return dumper.represent_scalar('!str', data.qualified_name)
 
     FormattedDumper.add_representer(dict, represent_dict)
     FormattedDumper.add_representer(common.ObjectName, represent_objname)

--- a/pgbedrock/core_generate.py
+++ b/pgbedrock/core_generate.py
@@ -448,8 +448,8 @@ def output_spec(spec):
         return dumper.represent_scalar('tag:yaml.org,2002:str', data.qualified_name)
         # return dumper.represent_scalar('!str', data.qualified_name)
 
-    yaml.add_representer(dict, represent_dict)
-    yaml.add_representer(common.ObjectName, represent_objname)
+    FormattedDumper.add_representer(dict, represent_dict)
+    FormattedDumper.add_representer(common.ObjectName, represent_objname)
 
     print(yaml.dump(spec, Dumper=FormattedDumper, default_flow_style=False, indent=4))
 

--- a/pgbedrock/core_generate.py
+++ b/pgbedrock/core_generate.py
@@ -239,8 +239,9 @@ def determine_schema_privileges(role, dbcontext):
     write_schemas_and_owners = dbcontext.get_role_current_nondefaults(role, 'schemas', 'write')
     read_schemas_and_owners = dbcontext.get_role_current_nondefaults(role,  'schemas', 'read')
 
-    write_schemas = {s for s, _ in write_schemas_and_owners}
-    read_schemas = {s for s, _ in read_schemas_and_owners}
+    # TODO: Use the DBObject instance instead of it's qualified_name
+    write_schemas = {s.qualified_name for s, _ in write_schemas_and_owners}
+    read_schemas = {s.qualified_name for s, _ in read_schemas_and_owners}
 
     # Get all schemas owned by this role
     all_owned_schemas = dbcontext.get_all_schemas_and_owners()

--- a/pgbedrock/core_generate.py
+++ b/pgbedrock/core_generate.py
@@ -219,7 +219,7 @@ def collapse_personal_schemas(role, objects, objkind, dbcontext):
 
     non_empty_personal_schemas = set()
     for objname in personal_schemas:
-        if objname.schema != role and not dbcontext.is_schema_empty(objname.schema, objkind):
+        if objname.schema != role and not dbcontext.is_schema_empty(objname, objkind):
             non_empty_personal_schemas.add(common.ObjectName(schema=objname.schema, unqualified_name='*'))
 
     if non_empty_personal_schemas.difference(objects) == set():

--- a/pgbedrock/core_generate.py
+++ b/pgbedrock/core_generate.py
@@ -358,7 +358,8 @@ def determine_nonschema_privileges_for_schema(role, objkind, objname, dbcontext)
         if entry.kind == objkind and entry.owner != role:
             schema_objects.add(entry.objname)
 
-    has_default_write = dbcontext.has_default_privilege(role, objname.schema, objkind, 'write')
+    has_default_write = dbcontext.has_default_privilege(role, objname, objkind, 'write')
+    # TODO: Convert the below to use ObjectNames
     all_writes = dbcontext.get_role_objects_with_access(role, objname.schema, objkind, 'write')
 
     if has_default_write or (all_writes == schema_objects and all_writes != set()):
@@ -368,7 +369,7 @@ def determine_nonschema_privileges_for_schema(role, objkind, objname, dbcontext)
 
     # If we haven't returned yet then no write default privilege exists; we will have to
     # grant each write individually, meaning we also need to look at read privileges
-    has_default_read = dbcontext.has_default_privilege(role, objname.schema, objkind, 'read')
+    has_default_read = dbcontext.has_default_privilege(role, objname, objkind, 'read')
     all_reads = dbcontext.get_role_objects_with_access(role, objname.schema, objkind, 'read')
 
     if has_default_read or (all_reads == schema_objects and all_reads != set()):

--- a/pgbedrock/core_generate.py
+++ b/pgbedrock/core_generate.py
@@ -325,7 +325,7 @@ def determine_nonschema_privileges_for_schema(role, objkind, schema, dbcontext):
     schema_objects = set()
     for entry in objects_and_owners:
         if entry.kind == objkind and entry.owner != role:
-            schema_objects.add(entry.name)
+            schema_objects.add(entry.dbobject.qualified_name)
 
     has_default_write = dbcontext.has_default_privilege(role, schema, objkind, 'write')
     all_writes_raw = dbcontext.get_role_objects_with_access(role, schema, objkind, 'write')

--- a/pgbedrock/core_generate.py
+++ b/pgbedrock/core_generate.py
@@ -165,8 +165,17 @@ def add_privileges(spec, dbcontext):
         for objkind in PRIVILEGE_MAP.keys():
             if objkind == 'schemas':
                 schemas_privs = determine_schema_privileges(role, dbcontext)
+
                 if schemas_privs:
-                    role_privileges['schemas'] = schemas_privs
+                    role_privileges['schemas'] = {}
+
+                # Render the schemas as strings and add them to the role's privilege dict
+                if 'write' in schemas_privs:
+                    rendered = sorted([dbo.qualified_name for dbo in schemas_privs['write']])
+                    role_privileges['schemas']['write'] = rendered
+                if 'read' in schemas_privs:
+                    rendered = sorted([dbo.qualified_name for dbo in schemas_privs['read']])
+                    role_privileges['schemas']['read'] = rendered
 
             else:
                 obj_privs = {}
@@ -275,9 +284,9 @@ def determine_schema_privileges(role, dbcontext):
 
     schemas_privs = {}
     if write_schemas:
-        schemas_privs['write'] = sorted([dbo.qualified_name for dbo in write_schemas])
+        schemas_privs['write'] = write_schemas
     if read_only_schemas:
-        schemas_privs['read'] = sorted([dbo.qualified_name for dbo in read_only_schemas])
+        schemas_privs['read'] = read_only_schemas
 
     return schemas_privs
 

--- a/pgbedrock/core_generate.py
+++ b/pgbedrock/core_generate.py
@@ -328,7 +328,9 @@ def determine_nonschema_privileges_for_schema(role, objkind, schema, dbcontext):
             schema_objects.add(entry.name)
 
     has_default_write = dbcontext.has_default_privilege(role, schema, objkind, 'write')
-    all_writes = dbcontext.get_role_objects_with_access(role, schema, objkind, 'write')
+    all_writes_raw = dbcontext.get_role_objects_with_access(role, schema, objkind, 'write')
+    # TODO: Remove the need for using DBObject.qualified_name
+    all_writes = set([i.qualified_name for i in all_writes_raw])
 
     if has_default_write or (all_writes == schema_objects and all_writes != set()):
         # In the second condition, every object has a write privilege, so we assume that means
@@ -338,7 +340,9 @@ def determine_nonschema_privileges_for_schema(role, objkind, schema, dbcontext):
     # If we haven't returned yet then no write default privilege exists; we will have to
     # grant each write individually, meaning we also need to look at read privileges
     has_default_read = dbcontext.has_default_privilege(role, schema, objkind, 'read')
-    all_reads = dbcontext.get_role_objects_with_access(role, schema, objkind, 'read')
+    all_reads_raw = dbcontext.get_role_objects_with_access(role, schema, objkind, 'read')
+    # TODO: Remove the need for using DBObject.qualified_name
+    all_reads = set([i.qualified_name for i in all_reads_raw])
 
     if has_default_read or (all_reads == schema_objects and all_reads != set()):
         # In the second condition, every object has a read privilege, so we assume that means

--- a/pgbedrock/ownerships.py
+++ b/pgbedrock/ownerships.py
@@ -36,15 +36,13 @@ def analyze_ownerships(spec, cursor, verbose):
             ownerships = config.get('owns', {})
             for objkind, objects_to_own in ownerships.items():
                 if objkind == 'schemas':
-                    for schema in objects_to_own:
-                        objname = common.ObjectName.from_str(schema)
+                    for objname in objects_to_own:
                         sql_to_run = SchemaAnalyzer(rolename=rolename, objname=objname,
                                                     dbcontext=dbcontext,
                                                     is_personal_schema=False).analyze()
                         all_sql_to_run += sql_to_run
                 else:
-                    for objname_as_str in objects_to_own:
-                        objname = common.ObjectName.from_str(objname_as_str)
+                    for objname in objects_to_own:
                         sql_to_run = NonschemaAnalyzer(rolename=rolename, objname=objname,
                                                        objkind=objkind, dbcontext=dbcontext).analyze()
                         all_sql_to_run += sql_to_run

--- a/pgbedrock/ownerships.py
+++ b/pgbedrock/ownerships.py
@@ -87,7 +87,7 @@ class NonschemaAnalyzer(object):
         return nondependent_objects
 
     def analyze(self):
-        if self.objname.object_name == '*':
+        if self.objname.unqualified_name == '*':
             objects_to_manage = self.expand_schema_objects(self.objname.schema)
         else:
             objects_to_manage = [self.objname]

--- a/pgbedrock/ownerships.py
+++ b/pgbedrock/ownerships.py
@@ -165,9 +165,10 @@ class SchemaAnalyzer(object):
         self.sql_to_run.append(query)
 
     def create_schema(self):
-        query = Q_CREATE_SCHEMA.format(self.objname.schema, self.rolename)
+        query = Q_CREATE_SCHEMA.format(self.objname.qualified_name, self.rolename)
         self.sql_to_run.append(query)
 
     def set_owner(self):
-        query = Q_SET_SCHEMA_OWNER.format(self.objname.schema, self.rolename, self.current_owner)
+        query = Q_SET_SCHEMA_OWNER.format(self.objname.qualified_name,
+                                          self.rolename, self.current_owner)
         self.sql_to_run.append(query)

--- a/pgbedrock/ownerships.py
+++ b/pgbedrock/ownerships.py
@@ -128,7 +128,7 @@ class SchemaAnalyzer(object):
         self.is_personal_schema = is_personal_schema
 
         self.current_owner = dbcontext.get_schema_owner(self.objname)
-        self.schema_objects = dbcontext.get_schema_objects(self.objname.schema)
+        self.schema_objects = dbcontext.get_schema_objects(self.objname)
         # If there is no owner then the schema must not exist yet
         self.exists = self.current_owner is not None
 

--- a/pgbedrock/ownerships.py
+++ b/pgbedrock/ownerships.py
@@ -133,7 +133,7 @@ class SchemaAnalyzer(object):
         objects = []
         for item in self.schema_objects:
             if item.owner != self.rolename and not item.is_dependent:
-                objects.append((item.kind, item.name, item.owner))
+                objects.append((item.kind, item.dbobject.qualified_name, item.owner))
         return objects
 
     def alter_object_owner(self, objkind, objname, prev_owner):

--- a/pgbedrock/ownerships.py
+++ b/pgbedrock/ownerships.py
@@ -129,7 +129,7 @@ class SchemaAnalyzer(object):
         self.dbobject = dbobject
         self.is_personal_schema = is_personal_schema
 
-        self.current_owner = dbcontext.get_schema_owner(self.dbobject.schema)
+        self.current_owner = dbcontext.get_schema_owner(self.dbobject)
         self.schema_objects = dbcontext.get_schema_objects(self.dbobject.schema)
         # If there is no owner then the schema must not exist yet
         self.exists = self.current_owner is not None

--- a/pgbedrock/privileges.py
+++ b/pgbedrock/privileges.py
@@ -214,13 +214,12 @@ class PrivilegeAnalyzer(object):
         defaults_to_grant = self.desired_defaults.difference(self.current_defaults)
         logger.debug('defaults_to_grant: {}'.format(defaults_to_grant))
         for grantor, schema, pg_priv_kind in sorted(defaults_to_grant):
-            #TODO: Pass ObjectNames and not strings here and below
-            self.grant_default(grantor, schema.qualified_name, pg_priv_kind)
+            self.grant_default(grantor, schema, pg_priv_kind)
 
         defaults_to_revoke = self.current_defaults.difference(self.desired_defaults)
         logger.debug('defaults_to_revoke: {}'.format(defaults_to_revoke))
         for grantor, schema, pg_priv_kind in sorted(defaults_to_revoke):
-            self.revoke_default(grantor, schema.qualified_name, pg_priv_kind)
+            self.revoke_default(grantor, schema, pg_priv_kind)
 
     def analyze_nondefaults(self):
         """ Analyze non-default privileges. Note that we sort the grants / revokes before issuing
@@ -274,7 +273,8 @@ class PrivilegeAnalyzer(object):
         return {objname for objname, attr in object_owners.items() if attr['owner'] != self.rolename}
 
     def grant_default(self, grantor, schema, privilege):
-        query = Q_GRANT_DEFAULT.format(grantor, schema, privilege, self.object_kind.upper(), self.rolename)
+        query = Q_GRANT_DEFAULT.format(grantor, schema.qualified_name, privilege,
+                                       self.object_kind.upper(), self.rolename)
         self.sql_to_run.append(query)
 
     def grant_nondefault(self, objname_as_str, privilege):
@@ -327,7 +327,8 @@ class PrivilegeAnalyzer(object):
             self.determine_desired_defaults([common.ObjectName(sch) for sch in schemas])
 
     def revoke_default(self, grantor, schema, privilege):
-        query = Q_REVOKE_DEFAULT.format(grantor, schema, privilege, self.object_kind.upper(), self.rolename)
+        query = Q_REVOKE_DEFAULT.format(grantor, schema.qualified_name, privilege,
+                                        self.object_kind.upper(), self.rolename)
         self.sql_to_run.append(query)
 
     def revoke_nondefault(self, objname_as_str, privilege):

--- a/pgbedrock/privileges.py
+++ b/pgbedrock/privileges.py
@@ -298,12 +298,12 @@ class PrivilegeAnalyzer(object):
         desired_nondefault_objs = set()
         schemas = []
         for objname in self.desired_items:
-            if objname.qualified_name == 'personal_schemas' and self.object_kind == 'schemas':
+            if objname == common.ObjectName('personal_schemas') and self.object_kind == 'schemas':
                 desired_nondefault_objs.update(self.personal_schemas)
-            elif objname.qualified_name == 'personal_schemas' and self.object_kind != 'schemas':
+            elif objname == common.ObjectName('personal_schemas') and self.object_kind != 'schemas':
                 # The end-user is asking something impossible
                 common.fail(PERSONAL_SCHEMAS_ERROR_MSG.format(self.rolename, self.object_kind, self.access))
-            elif objname.qualified_name == 'personal_schemas.*':
+            elif objname == common.ObjectName('personal_schemas', '*'):
                 schemas.extend(self.personal_schemas)
             elif objname.unqualified_name != '*':
                 # This is a single non-default privilege ask

--- a/pgbedrock/privileges.py
+++ b/pgbedrock/privileges.py
@@ -248,14 +248,8 @@ class PrivilegeAnalyzer(object):
 
     def get_object_owner(self, item, objkind=None):
         objkind = objkind or self.object_kind
-        # TODO: Remove this
-        schema = item.split('.', 1)[0]
-        if '.' in item:
-            objname_as_str = item.split('.', 1)[1]
-        else:
-            objname_as_str = None
-        objname = common.ObjectName(schema=schema, unqualified_name=objname_as_str)
-        object_owners = self.all_object_attrs.get(objkind, dict()).get(schema, dict())
+        objname = common.ObjectName.from_str(item)
+        object_owners = self.all_object_attrs.get(objkind, dict()).get(objname.schema, dict())
         owner = object_owners.get(objname, dict()).get('owner', None)
         if owner:
             return owner

--- a/pgbedrock/privileges.py
+++ b/pgbedrock/privileges.py
@@ -228,13 +228,13 @@ class PrivilegeAnalyzer(object):
         logger.debug('nondefaults_to_grant: {}'.format(nondefaults_to_grant))
         if nondefaults_to_grant:
             for objname, pg_priv_kind in sorted(nondefaults_to_grant):
-                self.grant_nondefault(objname.qualified_name, pg_priv_kind)
+                self.grant_nondefault(objname, pg_priv_kind)
 
         nondefaults_to_revoke = self.current_nondefaults.difference(self.desired_nondefaults)
         logger.debug('nondefaults_to_revoke: {}'.format(nondefaults_to_revoke))
         if nondefaults_to_revoke:
             for objname, pg_priv_kind in sorted(nondefaults_to_revoke):
-                self.revoke_nondefault(objname.qualified_name, pg_priv_kind)
+                self.revoke_nondefault(objname, pg_priv_kind)
 
     def determine_desired_defaults(self, schemas):
         """
@@ -277,9 +277,10 @@ class PrivilegeAnalyzer(object):
                                        self.object_kind.upper(), self.rolename)
         self.sql_to_run.append(query)
 
-    def grant_nondefault(self, objname_as_str, privilege):
+    def grant_nondefault(self, objname, privilege):
         obj_kind_singular = self.object_kind.upper()[:-1]
-        query = Q_GRANT_NONDEFAULT.format(privilege, obj_kind_singular, objname_as_str, self.rolename)
+        query = Q_GRANT_NONDEFAULT.format(privilege, obj_kind_singular,
+                                          objname.qualified_name, self.rolename)
         self.sql_to_run.append(query)
 
     def identify_desired_objects(self):
@@ -331,7 +332,8 @@ class PrivilegeAnalyzer(object):
                                         self.object_kind.upper(), self.rolename)
         self.sql_to_run.append(query)
 
-    def revoke_nondefault(self, objname_as_str, privilege):
+    def revoke_nondefault(self, objname, privilege):
         obj_kind_singular = self.object_kind.upper()[:-1]
-        query = Q_REVOKE_NONDEFAULT.format(privilege, obj_kind_singular, objname_as_str, self.rolename)
+        query = Q_REVOKE_NONDEFAULT.format(privilege, obj_kind_singular,
+                                           objname.qualified_name, self.rolename)
         self.sql_to_run.append(query)

--- a/pgbedrock/privileges.py
+++ b/pgbedrock/privileges.py
@@ -254,7 +254,7 @@ class PrivilegeAnalyzer(object):
             objname_as_str = item.split('.', 1)[1]
         else:
             objname_as_str = None
-        objname = common.ObjectName(schema=schema, object_name=objname_as_str)
+        objname = common.ObjectName(schema=schema, unqualified_name=objname_as_str)
         object_owners = self.all_object_attrs.get(objkind, dict()).get(schema, dict())
         owner = object_owners.get(objname, dict()).get('owner', None)
         if owner:

--- a/pgbedrock/privileges.py
+++ b/pgbedrock/privileges.py
@@ -194,11 +194,7 @@ class PrivilegeAnalyzer(object):
         self.personal_schemas = personal_schemas
         self.default_acl_possible = self.object_kind in OBJECTS_WITH_DEFAULTS
 
-        current_defaults = dbcontext.get_role_current_defaults(rolename, object_kind, access) or set()
-        #TODO: Remove the below
-        self.current_defaults = set([
-            (grantor, common.ObjectName(schema), pg_priv_kind) for grantor, schema, pg_priv_kind in current_defaults
-        ])
+        self.current_defaults = dbcontext.get_role_current_defaults(rolename, object_kind, access)
         self.current_nondefaults = dbcontext.get_role_current_nondefaults(rolename, object_kind, access)
 
         self.all_object_attrs = dbcontext.get_all_object_attributes()
@@ -218,6 +214,7 @@ class PrivilegeAnalyzer(object):
         defaults_to_grant = self.desired_defaults.difference(self.current_defaults)
         logger.debug('defaults_to_grant: {}'.format(defaults_to_grant))
         for grantor, schema, pg_priv_kind in sorted(defaults_to_grant):
+            #TODO: Pass ObjectNames and not strings here and below
             self.grant_default(grantor, schema.qualified_name, pg_priv_kind)
 
         defaults_to_revoke = self.current_defaults.difference(self.desired_defaults)

--- a/pgbedrock/privileges.py
+++ b/pgbedrock/privileges.py
@@ -187,7 +187,14 @@ class PrivilegeAnalyzer(object):
         self.default_acl_possible = self.object_kind in OBJECTS_WITH_DEFAULTS
 
         self.current_defaults = dbcontext.get_role_current_defaults(rolename, object_kind, access)
-        self.current_nondefaults = dbcontext.get_role_current_nondefaults(rolename, object_kind, access)
+
+        # TODO: Use the DBObject instance instead of it's qualified_name
+        current_nondefault_objects = dbcontext.get_role_current_nondefaults(rolename, object_kind, access)
+        if current_nondefault_objects:
+            self.current_nondefaults = set([(dbo.qualified_name, priv) for dbo, priv in current_nondefault_objects])
+        else:
+            self.current_nondefaults = set()
+
         self.all_object_attrs = dbcontext.get_all_object_attributes()
 
     def analyze(self):

--- a/pgbedrock/spec_inspector.py
+++ b/pgbedrock/spec_inspector.py
@@ -104,7 +104,7 @@ def ensure_no_object_owned_twice(spec, dbcontext, objkind):
         role_owned_objects = config['owns'][objkind]
         for objname_as_str in role_owned_objects:
             objname = common.ObjectName.from_str(objname_as_str)
-            if objname.object_name == '*':
+            if objname.unqualified_name == '*':
                 schema_objects = all_db_objects.get(objname.schema, dict())
                 nondependent_objects = [name for name, attr in schema_objects.items() if not attr['is_dependent']]
                 for obj in nondependent_objects:
@@ -262,7 +262,7 @@ def ensure_no_missing_objects(spec, dbcontext, objkind):
         role_owned_objects = config['owns'][objkind]
         for objname_as_str in role_owned_objects:
             objname = common.ObjectName.from_str(objname_as_str)
-            if objname.object_name == '*':
+            if objname.unqualified_name == '*':
                 schema_objects = db_objects_by_schema.get(objname.schema, dict())
                 nondependent_objects = [name for name, attr in schema_objects.items() if not attr['is_dependent']]
                 for obj in nondependent_objects:
@@ -318,7 +318,7 @@ def ensure_no_dependent_object_is_owned(spec, dbcontext, objkind):
         role_owned_objects = config['owns'][objkind]
         for objname_as_str in role_owned_objects:
             objname = common.ObjectName.from_str(objname_as_str)
-            if objname.object_name == '*':
+            if objname.unqualified_name == '*':
                 continue
 
             try:

--- a/pgbedrock/spec_inspector.py
+++ b/pgbedrock/spec_inspector.py
@@ -298,7 +298,7 @@ def ensure_no_unowned_schemas(spec, dbcontext):
     better to throw an error and ask the user to manually resolve this
     """
     current_schemas_and_owners = dbcontext.get_all_schemas_and_owners()
-    current_schemas = set(current_schemas_and_owners.keys())
+    current_schemas = set(dbobject.qualified_name for dbobject in current_schemas_and_owners.keys())
     spec_schemas = get_spec_schemas(spec)
     undocumented_schemas = current_schemas.difference(spec_schemas)
     if undocumented_schemas:

--- a/pgbedrock/spec_inspector.py
+++ b/pgbedrock/spec_inspector.py
@@ -398,7 +398,7 @@ def get_spec_schemas(spec):
         spec_schemas.extend(config.get('owns', {}).get('schemas', []))
 
         if config.get('has_personal_schema'):
-            spec_schemas.append(rolename)
+            spec_schemas.append(common.ObjectName(rolename))
 
     return set(spec_schemas)
 

--- a/pgbedrock/spec_inspector.py
+++ b/pgbedrock/spec_inspector.py
@@ -242,7 +242,7 @@ def ensure_no_missing_objects(spec, dbcontext, objkind):
     db_objects = set()
     for obj in dbcontext.get_all_raw_object_attributes():
         if obj.kind == objkind and not obj.is_dependent:
-            db_objects.add(obj.name.qualified_name)
+            db_objects.add(obj.dbobject.qualified_name)
 
     db_objects_by_schema = dbcontext.get_all_object_attributes().get(objkind, dict())
     spec_objects = set()

--- a/pgbedrock/spec_inspector.py
+++ b/pgbedrock/spec_inspector.py
@@ -242,7 +242,7 @@ def ensure_no_missing_objects(spec, dbcontext, objkind):
     db_objects = set()
     for obj in dbcontext.get_all_raw_object_attributes():
         if obj.kind == objkind and not obj.is_dependent:
-            db_objects.add(obj.name)
+            db_objects.add(obj.name.qualified_name)
 
     db_objects_by_schema = dbcontext.get_all_object_attributes().get(objkind, dict())
     spec_objects = set()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -84,3 +84,78 @@ def test_run_query_fails_not_verbose_mode(capsys, cursor):
         common.run_query(cursor, verbose=False, query='SELECT 1+1')
     expected_msg = common.FAILED_QUERY_MSG.format('SELECT 1+1', 'cursor already closed\n')
     assert expected_msg == capsys.readouterr()[0]
+
+
+def test_objectname_nonschema():
+    objname = common.ObjectName(schema='myschema', object_name='mytable')
+    assert objname.schema == 'myschema'
+    assert objname.object_name == 'mytable'
+    assert objname.qualified_name == 'myschema."mytable"'
+
+
+def test_objectname_schema():
+    objname = common.ObjectName(schema='myschema')
+    assert objname.schema == 'myschema'
+    assert objname.object_name is None
+    assert objname.qualified_name == 'myschema'
+
+
+def test_objectname_unquoted_item():
+    assert common.ObjectName._unquoted_item('foo') == 'foo'
+    assert common.ObjectName._unquoted_item('"foo"') == 'foo'
+
+
+def test_objectname_equivalence():
+    objname1 = common.ObjectName(schema='myschema', object_name='mytable')
+    objname2 = common.ObjectName(schema='myschema', object_name='mytable')
+    assert objname1 == objname2
+
+    objname1 = common.ObjectName(schema='myschema')
+    objname2 = common.ObjectName(schema='myschema')
+    assert objname1 == objname2
+
+
+def test_objectname_sorting():
+    list_of_objnames = [
+        common.ObjectName(schema='baz'),
+        common.ObjectName(schema='foo', object_name='gamma'),
+        common.ObjectName(schema='foo', object_name='alpha'),
+        common.ObjectName(schema='foo', object_name='bravo'),
+        common.ObjectName(schema='bar'),
+    ]
+    expected = [
+        common.ObjectName(schema='bar'),
+        common.ObjectName(schema='baz'),
+        common.ObjectName(schema='foo', object_name='alpha'),
+        common.ObjectName(schema='foo', object_name='bravo'),
+        common.ObjectName(schema='foo', object_name='gamma'),
+    ]
+
+    actual = sorted(list_of_objnames)
+    assert actual == expected
+
+
+@pytest.mark.parametrize('full_name', [('foo'), ('"foo"')])
+def test_objectname_from_str_only_schema(full_name):
+    objname = common.ObjectName.from_str(full_name)
+    assert isinstance(objname, common.ObjectName)
+    assert objname.schema == 'foo'
+    assert objname.object_name is None
+    assert objname.qualified_name == 'foo'
+
+
+@pytest.mark.parametrize('full_name, schema_name, object_name, qualified_name', [
+    ('foo.bar', 'foo', 'bar', 'foo."bar"'),
+    ('foo."bar"', 'foo', 'bar', 'foo."bar"'),
+    ('"foo".bar', 'foo', 'bar', 'foo."bar"'),
+    ('"foo"."bar"', 'foo', 'bar', 'foo."bar"'),
+    ('"foo".bar.baz', 'foo', 'bar.baz', 'foo."bar.baz"'),
+    ('"foo"."bar.baz"', 'foo', 'bar.baz', 'foo."bar.baz"'),
+    ('foo.*', 'foo', '*', 'foo.*'),
+])
+def test_objectname_from_str_schema_and_object(full_name, schema_name, object_name, qualified_name):
+    objname = common.ObjectName.from_str(full_name)
+    assert isinstance(objname, common.ObjectName)
+    assert objname.schema == schema_name
+    assert objname.object_name == object_name
+    assert objname.qualified_name == qualified_name

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -87,16 +87,16 @@ def test_run_query_fails_not_verbose_mode(capsys, cursor):
 
 
 def test_objectname_nonschema():
-    objname = common.ObjectName(schema='myschema', object_name='mytable')
+    objname = common.ObjectName(schema='myschema', unqualified_name='mytable')
     assert objname.schema == 'myschema'
-    assert objname.object_name == 'mytable'
+    assert objname.unqualified_name == 'mytable'
     assert objname.qualified_name == 'myschema."mytable"'
 
 
 def test_objectname_schema():
     objname = common.ObjectName(schema='myschema')
     assert objname.schema == 'myschema'
-    assert objname.object_name is None
+    assert objname.unqualified_name is None
     assert objname.qualified_name == 'myschema'
 
 
@@ -106,8 +106,8 @@ def test_objectname_unquoted_item():
 
 
 def test_objectname_equivalence():
-    objname1 = common.ObjectName(schema='myschema', object_name='mytable')
-    objname2 = common.ObjectName(schema='myschema', object_name='mytable')
+    objname1 = common.ObjectName(schema='myschema', unqualified_name='mytable')
+    objname2 = common.ObjectName(schema='myschema', unqualified_name='mytable')
     assert objname1 == objname2
 
     objname1 = common.ObjectName(schema='myschema')
@@ -118,17 +118,17 @@ def test_objectname_equivalence():
 def test_objectname_sorting():
     list_of_objnames = [
         common.ObjectName(schema='baz'),
-        common.ObjectName(schema='foo', object_name='gamma'),
-        common.ObjectName(schema='foo', object_name='alpha'),
-        common.ObjectName(schema='foo', object_name='bravo'),
+        common.ObjectName(schema='foo', unqualified_name='gamma'),
+        common.ObjectName(schema='foo', unqualified_name='alpha'),
+        common.ObjectName(schema='foo', unqualified_name='bravo'),
         common.ObjectName(schema='bar'),
     ]
     expected = [
         common.ObjectName(schema='bar'),
         common.ObjectName(schema='baz'),
-        common.ObjectName(schema='foo', object_name='alpha'),
-        common.ObjectName(schema='foo', object_name='bravo'),
-        common.ObjectName(schema='foo', object_name='gamma'),
+        common.ObjectName(schema='foo', unqualified_name='alpha'),
+        common.ObjectName(schema='foo', unqualified_name='bravo'),
+        common.ObjectName(schema='foo', unqualified_name='gamma'),
     ]
 
     actual = sorted(list_of_objnames)
@@ -140,11 +140,11 @@ def test_objectname_from_str_only_schema(full_name):
     objname = common.ObjectName.from_str(full_name)
     assert isinstance(objname, common.ObjectName)
     assert objname.schema == 'foo'
-    assert objname.object_name is None
+    assert objname.unqualified_name is None
     assert objname.qualified_name == 'foo'
 
 
-@pytest.mark.parametrize('full_name, schema_name, object_name, qualified_name', [
+@pytest.mark.parametrize('full_name, schema_name, unqualified_name, qualified_name', [
     ('foo.bar', 'foo', 'bar', 'foo."bar"'),
     ('foo."bar"', 'foo', 'bar', 'foo."bar"'),
     ('"foo".bar', 'foo', 'bar', 'foo."bar"'),
@@ -153,9 +153,9 @@ def test_objectname_from_str_only_schema(full_name):
     ('"foo"."bar.baz"', 'foo', 'bar.baz', 'foo."bar.baz"'),
     ('foo.*', 'foo', '*', 'foo.*'),
 ])
-def test_objectname_from_str_schema_and_object(full_name, schema_name, object_name, qualified_name):
+def test_objectname_from_str_schema_and_object(full_name, schema_name, unqualified_name, qualified_name):
     objname = common.ObjectName.from_str(full_name)
     assert isinstance(objname, common.ObjectName)
     assert objname.schema == schema_name
-    assert objname.object_name == object_name
+    assert objname.unqualified_name == unqualified_name
     assert objname.qualified_name == qualified_name

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -18,16 +18,6 @@ def test_check_name_succeeds():
     assert rolename == common.check_name(rolename)
 
 
-@pytest.mark.parametrize('input, expected', [
-    ('myschema.myschema.mytable', 'myschema."myschema.mytable"'),
-    ('myschema."myschema.mytable"', 'myschema."myschema.mytable"'),
-    ('myschema.mytable', 'myschema."mytable"'),
-    ('unqualified', 'unqualified'),
-])
-def test_ensure_quoted_identifier(input, expected):
-    assert common.ensure_quoted_identifier(input) == expected
-
-
 def test_get_db_connection_fails(capsys):
     with pytest.raises(SystemExit) as err:
         common.get_db_connection('foo', 'foo', 'foo', 'foo', 'foo')

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -115,6 +115,14 @@ def test_objectname_equivalence():
     assert objname1 == objname2
 
 
+def test_objectname_repr():
+    objname1 = common.ObjectName(schema='myschema')
+    assert repr(objname1) == "ObjectName('myschema')"
+
+    objname2 = common.ObjectName(schema='myschema', unqualified_name='mytable')
+    assert repr(objname2) == "ObjectName('myschema', 'mytable')"
+
+
 def test_objectname_sorting():
     list_of_objnames = [
         common.ObjectName(schema='baz'),

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -167,3 +167,10 @@ def test_objectname_from_str_schema_and_object(full_name, schema_name, unqualifi
     assert objname.schema == schema_name
     assert objname.unqualified_name == unqualified_name
     assert objname.qualified_name == qualified_name
+
+
+def test_objectname_only_schema():
+    objname = common.ObjectName(schema='myschema', unqualified_name='mytable')
+    only_schema = objname.only_schema()
+    assert only_schema.qualified_name == 'myschema'
+    assert only_schema.unqualified_name is None

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -191,8 +191,8 @@ def test_get_all_current_nondefaults(cursor):
         ROLES[0]: {
             'tables': {
                 'read': set([
-                    (quoted_object(SCHEMAS[0], TABLES[1]), 'SELECT'),
-                    (quoted_object(SCHEMAS[1], TABLES[3]), 'SELECT'),
+                    (context.DBObject(schema=SCHEMAS[0], object_name=TABLES[1]), 'SELECT'),
+                    (context.DBObject(schema=SCHEMAS[1], object_name=TABLES[3]), 'SELECT'),
                 ]),
                 'write': set(),
             }
@@ -201,8 +201,8 @@ def test_get_all_current_nondefaults(cursor):
             'schemas': {
                 'read': set(),
                 'write': set([
-                    (SCHEMAS[0], 'CREATE'),
-                    (SCHEMAS[1], 'CREATE'),
+                    (context.DBObject(schema=SCHEMAS[0]), 'CREATE'),
+                    (context.DBObject(schema=SCHEMAS[1]), 'CREATE'),
                 ]),
             }
         },
@@ -210,8 +210,8 @@ def test_get_all_current_nondefaults(cursor):
             'schemas': {
                 'read': set(),
                 'write': set([
-                    (SCHEMAS[0], 'CREATE'),
-                    (SCHEMAS[1], 'CREATE'),
+                    (context.DBObject(schema=SCHEMAS[0]), 'CREATE'),
+                    (context.DBObject(schema=SCHEMAS[1]), 'CREATE'),
                 ]),
             }
         }
@@ -228,7 +228,11 @@ def test_get_all_current_nondefaults(cursor):
 
 
 @pytest.mark.parametrize('rolename, object_kind, access, expected', [
-    ('role1', 'object_kind1', 'access1', set([1, 2, 3])),
+    ('role1', 'object_kind1', 'access1', set([
+        ('foo."bar"', 'SELECT'),
+        ('foo."baz"', 'SELECT'),
+        ('foo."qux"', 'INSERT')
+    ])),
     ('role1', 'object_kind1', 'missing_access', set()),
     ('role1', 'missing_object_kind1', 'access1', set()),
     ('missing_role1', 'object_kind1', 'access', set()),
@@ -238,11 +242,16 @@ def test_get_role_current_nondefaults(rolename, object_kind, access, expected):
     dbcontext._cache['get_all_current_nondefaults'] = lambda: {
         'role1': {
             'object_kind1': {
-                'access1': set([1, 2, 3])
+                'access1': set([
+                    (context.DBObject(schema='foo', object_name='bar'), 'SELECT'),
+                    (context.DBObject(schema='foo', object_name='baz'), 'SELECT'),
+                    (context.DBObject(schema='foo', object_name='qux'), 'INSERT'),
+                ])
             }
         }
     }
-    assert dbcontext.get_role_current_nondefaults(rolename, object_kind, access) == expected
+    actual = dbcontext.get_role_current_nondefaults(rolename, object_kind, access)
+    assert actual == expected
 
 
 
@@ -260,8 +269,8 @@ def test_get_role_objects_with_access(access, expected):
         ROLES[0]: {
             'tables': {
                 'read': set([
-                    (quoted_object(SCHEMAS[0], TABLES[0]), 'SELECT'),
-                    (quoted_object(SCHEMAS[0], TABLES[1]), 'SELECT'),
+                    (context.DBObject(schema=SCHEMAS[0], object_name=TABLES[0]), 'SELECT'),
+                    (context.DBObject(schema=SCHEMAS[0], object_name=TABLES[1]), 'SELECT'),
                 ])
             }
         }

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -525,13 +525,13 @@ def test_get_all_nonschema_objects_and_owners(cursor):
     expected = {
         SCHEMAS[0]:
         [
-            context.ObjectInfo('tables', quoted_object(SCHEMAS[0], TABLES[0]), ROLES[0], False),
-            context.ObjectInfo('sequences', quoted_object(SCHEMAS[0], SEQUENCES[1]), ROLES[0], False),
+            context.ObjectInfo('tables', context.DBObject(schema=SCHEMAS[0], object_name=TABLES[0]), ROLES[0], False),
+            context.ObjectInfo('sequences', context.DBObject(schema=SCHEMAS[0], object_name=SEQUENCES[1]), ROLES[0], False),
         ],
         SCHEMAS[1]:
         [
-            context.ObjectInfo('tables', quoted_object(SCHEMAS[1], TABLES[0]), ROLES[1], False),
-            context.ObjectInfo('sequences', quoted_object(SCHEMAS[1], SEQUENCES[2]), ROLES[1], False),
+            context.ObjectInfo('tables', context.DBObject(schema=SCHEMAS[1], object_name=TABLES[0]), ROLES[1], False),
+            context.ObjectInfo('sequences', context.DBObject(schema=SCHEMAS[1], object_name=SEQUENCES[2]), ROLES[1], False),
         ],
     }
     actual = dbcontext.get_all_nonschema_objects_and_owners()
@@ -549,10 +549,7 @@ def test_get_all_nonschema_objects_and_owners(cursor):
 
 def test_get_schema_objects():
     schema = 'foo'
-    expected = [
-        context.ObjectInfo('tables', quoted_object(SCHEMAS[0], TABLES[0]), ROLES[0], False),
-        context.ObjectInfo('sequences', quoted_object(SCHEMAS[0], SEQUENCES[1]), ROLES[0], False),
-    ]
+    expected = 'bar'
     dbcontext = context.DatabaseContext(cursor=DUMMY, verbose=False)
     dbcontext._cache['get_all_nonschema_objects_and_owners'] = lambda: {schema: expected}
     actual = dbcontext.get_schema_objects(schema)
@@ -562,10 +559,7 @@ def test_get_schema_objects():
 def test_get_schema_objects_no_entry():
     dbcontext = context.DatabaseContext(cursor=DUMMY, verbose=False)
     dbcontext._cache['get_all_nonschema_objects_and_owners'] = lambda: {
-        'foo': [
-            context.ObjectInfo('tables', quoted_object(SCHEMAS[0], TABLES[0]), ROLES[0], False),
-            context.ObjectInfo('sequences', quoted_object(SCHEMAS[0], SEQUENCES[1]), ROLES[0], False),
-        ],
+        'foo': 'bar',
     }
     actual = dbcontext.get_schema_objects('key_not_in_response')
     assert actual == []

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -61,7 +61,7 @@ def test_dbobject_from_str_only_schema(full_name):
     ('"foo"."bar"', 'foo', 'bar', 'foo."bar"'),
     ('"foo".bar.baz', 'foo', 'bar.baz', 'foo."bar.baz"'),
     ('"foo"."bar.baz"', 'foo', 'bar.baz', 'foo."bar.baz"'),
-    ('foo.*', 'foo', '*', 'foo."*"'),
+    ('foo.*', 'foo', '*', 'foo.*'),
 ])
 def test_objectname_from_str_schema_and_object(full_name, schema_name, object_name, qualified_name):
     myobj = context.DBObject.from_str(full_name)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -442,14 +442,14 @@ def test_is_superuser(all_role_attributes, expected):
 def test_get_all_schemas_and_owners(cursor):
     dbcontext = context.DatabaseContext(cursor, verbose=True)
     expected = {
-        SCHEMAS[0]: ROLES[0],
-        SCHEMAS[1]: ROLES[0],
-        SCHEMAS[2]: ROLES[1],
-        ROLES[1]: ROLES[1],
+        context.DBObject(SCHEMAS[0]): ROLES[0],
+        context.DBObject(SCHEMAS[1]): ROLES[0],
+        context.DBObject(SCHEMAS[2]): ROLES[1],
+        context.DBObject(ROLES[1]): ROLES[1],
         # These already existed
-        'public': 'postgres',
-        'information_schema': 'postgres',
-        'pg_catalog': 'postgres',
+        context.DBObject('public'): 'postgres',
+        context.DBObject('information_schema'): 'postgres',
+        context.DBObject('pg_catalog'): 'postgres',
     }
 
     actual = dbcontext.get_all_schemas_and_owners()
@@ -496,7 +496,7 @@ def test_get_all_memberships(cursor):
 
 
 def test_get_schema_owner():
-    schema = 'foo'
+    schema = context.DBObject('foo')
     expected_owner = 'bar'
     dbcontext = context.DatabaseContext(cursor=DUMMY, verbose=True)
     dbcontext._cache['get_all_schemas_and_owners'] = lambda: {schema: expected_owner}

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -229,9 +229,9 @@ def test_get_all_current_nondefaults(cursor):
 
 @pytest.mark.parametrize('rolename, object_kind, access, expected', [
     ('role1', 'object_kind1', 'access1', set([
-        ('foo."bar"', 'SELECT'),
-        ('foo."baz"', 'SELECT'),
-        ('foo."qux"', 'INSERT')
+        (context.DBObject(schema='foo', object_name='bar'), 'SELECT'),
+        (context.DBObject(schema='foo', object_name='baz'), 'SELECT'),
+        (context.DBObject(schema='foo', object_name='qux'), 'INSERT'),
     ])),
     ('role1', 'object_kind1', 'missing_access', set()),
     ('role1', 'missing_object_kind1', 'access1', set()),

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -218,7 +218,8 @@ def test_get_role_objects_with_access(access, expected):
             }
         }
     }
-    actual = dbcontext.get_role_objects_with_access(ROLES[0], SCHEMAS[0], 'tables', access)
+    actual = dbcontext.get_role_objects_with_access(ROLES[0], common.ObjectName(SCHEMAS[0]),
+                                                    'tables', access)
     assert actual == expected
 
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -40,7 +40,7 @@ def test_get_all_current_defaults(cursor):
         ROLES[0]: {
             'tables': {
                 'read': set([
-                    (ROLES[3], SCHEMAS[0], 'SELECT'),
+                    (ROLES[3], common.ObjectName(SCHEMAS[0]), 'SELECT'),
                 ]),
                 'write': set(),
             }
@@ -92,10 +92,10 @@ def test_has_default_privilege(rolename, schema, object_kind, access, expected):
         'role1': {
             'tables': {
                 'read': set([
-                    ('role1', 'schema2', 'SELECT'),
+                    ('role1', common.ObjectName('schema2'), 'SELECT'),
                 ]),
                 'write': set([
-                    ('not_this_role', 'schema1', 'UPDATE'),
+                    ('not_this_role', common.ObjectName('schema1'), 'UPDATE'),
                 ]),
             }
         }

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -308,21 +308,21 @@ def test_get_all_object_attributes(cursor):
     expected = {
         'tables': {
             SCHEMAS[0]: {
-                quoted_object(SCHEMAS[0], TABLES[0]): {'owner': ROLES[1], 'is_dependent': False},
-                quoted_object(SCHEMAS[0], TABLES[1]): {'owner': ROLES[1], 'is_dependent': False},
-                quoted_object(SCHEMAS[0], TABLES[2]): {'owner': ROLES[3], 'is_dependent': False},
+                context.DBObject(SCHEMAS[0], TABLES[0]): {'owner': ROLES[1], 'is_dependent': False},
+                context.DBObject(SCHEMAS[0], TABLES[1]): {'owner': ROLES[1], 'is_dependent': False},
+                context.DBObject(SCHEMAS[0], TABLES[2]): {'owner': ROLES[3], 'is_dependent': False},
             }
         },
         'sequences': {
             SCHEMAS[0]: {
-                quoted_object(SCHEMAS[0], SEQUENCES[0]): {'owner': ROLES[1], 'is_dependent': False},
-                quoted_object(SCHEMAS[0], SEQUENCES[1]): {'owner': ROLES[2], 'is_dependent': False},
-                quoted_object(SCHEMAS[0], SEQUENCES[2]): {'owner': ROLES[2], 'is_dependent': False},
+                context.DBObject(SCHEMAS[0], SEQUENCES[0]): {'owner': ROLES[1], 'is_dependent': False},
+                context.DBObject(SCHEMAS[0], SEQUENCES[1]): {'owner': ROLES[2], 'is_dependent': False},
+                context.DBObject(SCHEMAS[0], SEQUENCES[2]): {'owner': ROLES[2], 'is_dependent': False},
             }
         },
         'schemas': {
             SCHEMAS[0]: {
-                SCHEMAS[0]: {'owner': ROLES[0], 'is_dependent': False},
+                context.DBObject(SCHEMAS[0]): {'owner': ROLES[0], 'is_dependent': False},
             },
             'public': {
                 'public': {'owner': 'postgres', 'is_dependent': False},

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -466,13 +466,11 @@ def test_get_schema_owner():
 def test_get_all_nonschema_objects_and_owners(cursor):
     dbcontext = context.DatabaseContext(cursor, verbose=True)
     expected = {
-        SCHEMAS[0]:
-        [
+        common.ObjectName(SCHEMAS[0]): [
             context.ObjectInfo('tables', common.ObjectName(SCHEMAS[0], TABLES[0]), ROLES[0], False),
             context.ObjectInfo('sequences', common.ObjectName(SCHEMAS[0], SEQUENCES[1]), ROLES[0], False),
         ],
-        SCHEMAS[1]:
-        [
+        common.ObjectName(SCHEMAS[1]): [
             context.ObjectInfo('tables', common.ObjectName(SCHEMAS[1], TABLES[0]), ROLES[1], False),
             context.ObjectInfo('sequences', common.ObjectName(SCHEMAS[1], SEQUENCES[2]), ROLES[1], False),
         ],
@@ -494,7 +492,9 @@ def test_get_schema_objects():
     schema = common.ObjectName('foo')
     expected = 'bar'
     dbcontext = context.DatabaseContext(cursor=DUMMY, verbose=False)
-    dbcontext._cache['get_all_nonschema_objects_and_owners'] = lambda: {'foo': expected}
+    dbcontext._cache['get_all_nonschema_objects_and_owners'] = lambda: {
+        common.ObjectName('foo'): expected
+    }
     actual = dbcontext.get_schema_objects(schema)
     assert actual == expected
 
@@ -502,7 +502,7 @@ def test_get_schema_objects():
 def test_get_schema_objects_no_entry():
     dbcontext = context.DatabaseContext(cursor=DUMMY, verbose=False)
     dbcontext._cache['get_all_nonschema_objects_and_owners'] = lambda: {
-        'foo': 'bar',
+        common.ObjectName('foo'): 'bar',
     }
     actual = dbcontext.get_schema_objects(common.ObjectName('key_not_in_response'))
     assert actual == []

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -45,6 +45,26 @@ def test_dbobject_equivalence():
     assert myobj1 == myobj2
 
 
+def test_dbobject_sorting():
+    list_of_dbobjects = [
+        context.DBObject(schema='baz'),
+        context.DBObject(schema='foo', object_name='gamma'),
+        context.DBObject(schema='foo', object_name='alpha'),
+        context.DBObject(schema='foo', object_name='bravo'),
+        context.DBObject(schema='bar'),
+    ]
+    expected = [
+        context.DBObject(schema='bar'),
+        context.DBObject(schema='baz'),
+        context.DBObject(schema='foo', object_name='alpha'),
+        context.DBObject(schema='foo', object_name='bravo'),
+        context.DBObject(schema='foo', object_name='gamma'),
+    ]
+
+    actual = sorted(list_of_dbobjects)
+    assert actual == expected
+
+
 @pytest.mark.parametrize('full_name', [('foo'), ('"foo"')])
 def test_dbobject_from_str_only_schema(full_name):
     myobj = context.DBObject.from_str(full_name)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -78,13 +78,13 @@ def test_get_role_current_defaults(rolename, object_kind, access, expected):
 
 @pytest.mark.parametrize('rolename, schema, object_kind, access, expected', [
     # No privilege --> false
-    ('role1', 'schema1', 'tables', 'read', False),
+    ('role1', common.ObjectName('schema1'), 'tables', 'read', False),
     # Privilege exists --> True
-    ('role1', 'schema1', 'tables', 'write', True),
+    ('role1', common.ObjectName('schema1'), 'tables', 'write', True),
     # Grantor is this role --> False
-    ('role1', 'schema2', 'tables', 'read', False),
+    ('role1', common.ObjectName('schema2'), 'tables', 'read', False),
     # No entries exist --> False
-    ('role1', DUMMY, 'objkind_does_not_exist', DUMMY, False),
+    ('role1', common.ObjectName(DUMMY), 'objkind_does_not_exist', DUMMY, False),
 ])
 def test_has_default_privilege(rolename, schema, object_kind, access, expected):
     dbcontext = context.DatabaseContext(cursor=DUMMY, verbose=True)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -491,10 +491,10 @@ def test_get_all_nonschema_objects_and_owners(cursor):
 
 
 def test_get_schema_objects():
-    schema = 'foo'
+    schema = common.ObjectName('foo')
     expected = 'bar'
     dbcontext = context.DatabaseContext(cursor=DUMMY, verbose=False)
-    dbcontext._cache['get_all_nonschema_objects_and_owners'] = lambda: {schema: expected}
+    dbcontext._cache['get_all_nonschema_objects_and_owners'] = lambda: {'foo': expected}
     actual = dbcontext.get_schema_objects(schema)
     assert actual == expected
 
@@ -504,7 +504,7 @@ def test_get_schema_objects_no_entry():
     dbcontext._cache['get_all_nonschema_objects_and_owners'] = lambda: {
         'foo': 'bar',
     }
-    actual = dbcontext.get_schema_objects('key_not_in_response')
+    actual = dbcontext.get_schema_objects(common.ObjectName('key_not_in_response'))
     assert actual == []
 
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -134,8 +134,8 @@ def test_get_all_current_nondefaults(cursor):
         ROLES[0]: {
             'tables': {
                 'read': set([
-                    (common.ObjectName(schema=SCHEMAS[0], object_name=TABLES[1]), 'SELECT'),
-                    (common.ObjectName(schema=SCHEMAS[1], object_name=TABLES[3]), 'SELECT'),
+                    (common.ObjectName(SCHEMAS[0], TABLES[1]), 'SELECT'),
+                    (common.ObjectName(SCHEMAS[1], TABLES[3]), 'SELECT'),
                 ]),
                 'write': set(),
             }
@@ -172,9 +172,9 @@ def test_get_all_current_nondefaults(cursor):
 
 @pytest.mark.parametrize('rolename, object_kind, access, expected', [
     ('role1', 'object_kind1', 'access1', set([
-        (common.ObjectName(schema='foo', object_name='bar'), 'SELECT'),
-        (common.ObjectName(schema='foo', object_name='baz'), 'SELECT'),
-        (common.ObjectName(schema='foo', object_name='qux'), 'INSERT'),
+        (common.ObjectName('foo', 'bar'), 'SELECT'),
+        (common.ObjectName('foo', 'baz'), 'SELECT'),
+        (common.ObjectName('foo', 'qux'), 'INSERT'),
     ])),
     ('role1', 'object_kind1', 'missing_access', set()),
     ('role1', 'missing_object_kind1', 'access1', set()),
@@ -186,9 +186,9 @@ def test_get_role_current_nondefaults(rolename, object_kind, access, expected):
         'role1': {
             'object_kind1': {
                 'access1': set([
-                    (common.ObjectName(schema='foo', object_name='bar'), 'SELECT'),
-                    (common.ObjectName(schema='foo', object_name='baz'), 'SELECT'),
-                    (common.ObjectName(schema='foo', object_name='qux'), 'INSERT'),
+                    (common.ObjectName('foo', 'bar'), 'SELECT'),
+                    (common.ObjectName('foo', 'baz'), 'SELECT'),
+                    (common.ObjectName('foo', 'qux'), 'INSERT'),
                 ])
             }
         }
@@ -202,8 +202,8 @@ def test_get_role_current_nondefaults(rolename, object_kind, access, expected):
 @pytest.mark.parametrize('access, expected', [
     ('write', set()),
     ('read', set([
-        common.ObjectName(schema=SCHEMAS[0], object_name=TABLES[0]),
-        common.ObjectName(schema=SCHEMAS[0], object_name=TABLES[1])
+        common.ObjectName(SCHEMAS[0], TABLES[0]),
+        common.ObjectName(SCHEMAS[0], TABLES[1])
     ])),
 ])
 def test_get_role_objects_with_access(access, expected):
@@ -212,8 +212,8 @@ def test_get_role_objects_with_access(access, expected):
         ROLES[0]: {
             'tables': {
                 'read': set([
-                    (common.ObjectName(schema=SCHEMAS[0], object_name=TABLES[0]), 'SELECT'),
-                    (common.ObjectName(schema=SCHEMAS[0], object_name=TABLES[1]), 'SELECT'),
+                    (common.ObjectName(SCHEMAS[0], TABLES[0]), 'SELECT'),
+                    (common.ObjectName(SCHEMAS[0], TABLES[1]), 'SELECT'),
                 ])
             }
         }
@@ -468,13 +468,13 @@ def test_get_all_nonschema_objects_and_owners(cursor):
     expected = {
         SCHEMAS[0]:
         [
-            context.ObjectInfo('tables', common.ObjectName(schema=SCHEMAS[0], object_name=TABLES[0]), ROLES[0], False),
-            context.ObjectInfo('sequences', common.ObjectName(schema=SCHEMAS[0], object_name=SEQUENCES[1]), ROLES[0], False),
+            context.ObjectInfo('tables', common.ObjectName(SCHEMAS[0], TABLES[0]), ROLES[0], False),
+            context.ObjectInfo('sequences', common.ObjectName(SCHEMAS[0], SEQUENCES[1]), ROLES[0], False),
         ],
         SCHEMAS[1]:
         [
-            context.ObjectInfo('tables', common.ObjectName(schema=SCHEMAS[1], object_name=TABLES[0]), ROLES[1], False),
-            context.ObjectInfo('sequences', common.ObjectName(schema=SCHEMAS[1], object_name=SEQUENCES[2]), ROLES[1], False),
+            context.ObjectInfo('tables', common.ObjectName(SCHEMAS[1], TABLES[0]), ROLES[1], False),
+            context.ObjectInfo('sequences', common.ObjectName(SCHEMAS[1], SEQUENCES[2]), ROLES[1], False),
         ],
     }
     actual = dbcontext.get_all_nonschema_objects_and_owners()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -20,14 +20,14 @@ def test_dbobject_nonschema():
     myobj = context.DBObject(schema='myschema', object_name='mytable')
     assert myobj.schema == 'myschema'
     assert myobj.object_name == 'mytable'
-    assert myobj.qualified_name == '"myschema"."mytable"'
+    assert myobj.qualified_name == 'myschema."mytable"'
 
 
 def test_dbobject_schema():
     myobj = context.DBObject(schema='myschema')
     assert myobj.schema == 'myschema'
     assert myobj.object_name is None
-    assert myobj.qualified_name == '"myschema"'
+    assert myobj.qualified_name == 'myschema'
 
 
 def test_dbobject_unquoted_item():
@@ -51,17 +51,17 @@ def test_dbobject_from_str_only_schema(full_name):
     assert isinstance(myobj, context.DBObject)
     assert myobj.schema == 'foo'
     assert myobj.object_name is None
-    assert myobj.qualified_name == '"foo"'
+    assert myobj.qualified_name == 'foo'
 
 
 @pytest.mark.parametrize('full_name, schema_name, object_name, qualified_name', [
-    ('foo.bar', 'foo', 'bar', '"foo"."bar"'),
-    ('foo."bar"', 'foo', 'bar', '"foo"."bar"'),
-    ('"foo".bar', 'foo', 'bar', '"foo"."bar"'),
-    ('"foo"."bar"', 'foo', 'bar', '"foo"."bar"'),
-    ('"foo".bar.baz', 'foo', 'bar.baz', '"foo"."bar.baz"'),
-    ('"foo"."bar.baz"', 'foo', 'bar.baz', '"foo"."bar.baz"'),
-    ('foo.*', 'foo', '*', '"foo"."*"'),
+    ('foo.bar', 'foo', 'bar', 'foo."bar"'),
+    ('foo."bar"', 'foo', 'bar', 'foo."bar"'),
+    ('"foo".bar', 'foo', 'bar', 'foo."bar"'),
+    ('"foo"."bar"', 'foo', 'bar', 'foo."bar"'),
+    ('"foo".bar.baz', 'foo', 'bar.baz', 'foo."bar.baz"'),
+    ('"foo"."bar.baz"', 'foo', 'bar.baz', 'foo."bar.baz"'),
+    ('foo.*', 'foo', '*', 'foo."*"'),
 ])
 def test_objectname_from_str_schema_and_object(full_name, schema_name, object_name, qualified_name):
     myobj = context.DBObject.from_str(full_name)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -259,8 +259,8 @@ def test_get_role_current_nondefaults(rolename, object_kind, access, expected):
 @pytest.mark.parametrize('access, expected', [
     ('write', set()),
     ('read', set([
-        quoted_object(SCHEMAS[0], TABLES[0]),
-        quoted_object(SCHEMAS[0], TABLES[1])
+        context.DBObject(schema=SCHEMAS[0], object_name=TABLES[0]),
+        context.DBObject(schema=SCHEMAS[0], object_name=TABLES[1])
     ])),
 ])
 def test_get_role_objects_with_access(access, expected):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -360,7 +360,7 @@ def test_get_all_object_attributes(cursor):
 def test_get_all_personal_schemas(cursor):
     dbcontext = context.DatabaseContext(cursor, verbose=True)
     actual = dbcontext.get_all_personal_schemas()
-    expected = set(ROLES[1:3])
+    expected = set([context.DBObject(schema) for schema in ROLES[1:3]])
     assert actual == expected
 
     # Make sure that this data is cached for future use

--- a/tests/test_core_generate.py
+++ b/tests/test_core_generate.py
@@ -117,7 +117,7 @@ def test_add_schema_ownerships(mockdbcontext):
         # Would not show up in get_all_personal_schemas as can_login is False
         'owner2': 'owner2',
     }
-    mockdbcontext.get_all_personal_schemas = lambda: set(['owner1'])
+    mockdbcontext.get_all_personal_schemas = lambda: set([DBObject('owner1')])
 
     spec = {
         'owner1': {'can_login': True},
@@ -157,7 +157,7 @@ def test_add_nonschema_ownerships(mockdbcontext):
         },
         'sequences': {},
     }
-    mockdbcontext.get_all_personal_schemas = lambda: set(['owner3', 'owner5'])
+    mockdbcontext.get_all_personal_schemas = lambda: set([DBObject('owner3'), DBObject('owner5')])
 
     spec = {
         'owner1': {
@@ -189,7 +189,7 @@ def test_add_nonschema_ownerships_empty_objkinds(mockdbcontext, objkind):
         },
         'sequences': {},
     }
-    mockdbcontext.get_all_personal_schemas = lambda: set(['owner4', 'owner5'])
+    mockdbcontext.get_all_personal_schemas = lambda: set([DBObject('owner4'), DBObject('owner5')])
 
     spec = {
         'owner1': {
@@ -245,7 +245,7 @@ def test_add_ownerships(mockdbcontext):
         # Personal schema
         'owner3': 'owner3',
     }
-    mockdbcontext.get_all_personal_schemas = lambda: set(['owner3'])
+    mockdbcontext.get_all_personal_schemas = lambda: set([DBObject('owner3')])
 
     spec = {
         'owner1': {},

--- a/tests/test_core_generate.py
+++ b/tests/test_core_generate.py
@@ -139,20 +139,20 @@ def test_add_nonschema_ownerships(mockdbcontext):
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             'schema1': {
-                quoted_object('schema1', 'mytable1'): {'owner': 'owner1', 'is_dependent': False},
+                DBObject('schema1', 'mytable1'): {'owner': 'owner1', 'is_dependent': False},
                 # This entry should be skipped because it is dependent
-                quoted_object('schema1', 'mytable2'): {'owner': 'owner2', 'is_dependent': True},
-                quoted_object('schema1', 'mytable3'): {'owner': 'owner2', 'is_dependent': False},
+                DBObject('schema1', 'mytable2'): {'owner': 'owner2', 'is_dependent': True},
+                DBObject('schema1', 'mytable3'): {'owner': 'owner2', 'is_dependent': False},
             },
             'schema2': {
                 # These all have the same owner, so it will become schema2.*
-                quoted_object('schema2', 'mytable4'): {'owner': 'owner1', 'is_dependent': False},
-                quoted_object('schema2', 'mytable5'): {'owner': 'owner1', 'is_dependent': False},
-                quoted_object('schema2', 'mytable6'): {'owner': 'owner1', 'is_dependent': False},
+                DBObject('schema2', 'mytable4'): {'owner': 'owner1', 'is_dependent': False},
+                DBObject('schema2', 'mytable5'): {'owner': 'owner1', 'is_dependent': False},
+                DBObject('schema2', 'mytable6'): {'owner': 'owner1', 'is_dependent': False},
             },
             'owner3': {
                 # This entry should be skipped because it is in a personal schema
-                quoted_object('owner3', 'mytable7'): {'owner': 'owner2', 'is_dependent': False},
+                DBObject('owner3', 'mytable7'): {'owner': 'owner2', 'is_dependent': False},
             },
         },
         'sequences': {},
@@ -172,11 +172,8 @@ def test_add_nonschema_ownerships(mockdbcontext):
 
     actual = core_generate.add_nonschema_ownerships(spec, mockdbcontext, 'tables')
     assert actual['owner1']['owns']['schemas'] == ['schema1']
-    assert set(actual['owner1']['owns']['tables']) == set([
-        quoted_object('schema1', 'mytable1'),
-        'schema2.*',
-    ])
-    assert actual['owner2']['owns']['tables'] == [quoted_object('schema1', 'mytable3')]
+    assert set(actual['owner1']['owns']['tables']) == set(['schema1."mytable1"', 'schema2."*"'])
+    assert actual['owner2']['owns']['tables'] == ['schema1."mytable3"']
     assert actual['owner3'] == {}
     assert actual['owner4'] == {}
 
@@ -210,30 +207,30 @@ def test_add_ownerships(mockdbcontext):
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             'schema1': {
-                quoted_object('schema1', 'mytable1'): {'owner': 'owner1', 'is_dependent': False},
+                DBObject('schema1', 'mytable1'): {'owner': 'owner1', 'is_dependent': False},
                 # This entry should be skipped because it is dependent
-                quoted_object('schema1', 'mytable2'): {'owner': 'owner2', 'is_dependent': True},
-                quoted_object('schema1', 'mytable3'): {'owner': 'owner2', 'is_dependent': False},
+                DBObject('schema1', 'mytable2'): {'owner': 'owner2', 'is_dependent': True},
+                DBObject('schema1', 'mytable3'): {'owner': 'owner2', 'is_dependent': False},
             },
             'schema2': {
                 # These all have the same owner, so it will become schema2.*
-                quoted_object('schema2', 'mytable4'): {'owner': 'owner1', 'is_dependent': False},
-                quoted_object('schema2', 'mytable5'): {'owner': 'owner1', 'is_dependent': False},
-                quoted_object('schema2', 'mytable6'): {'owner': 'owner1', 'is_dependent': False},
+                DBObject('schema2', 'mytable4'): {'owner': 'owner1', 'is_dependent': False},
+                DBObject('schema2', 'mytable5'): {'owner': 'owner1', 'is_dependent': False},
+                DBObject('schema2', 'mytable6'): {'owner': 'owner1', 'is_dependent': False},
             },
             'owner3': {
                 # This entry should be skipped because it is in a personal schema
-                quoted_object('owner3', 'mytable7'): {'owner': 'owner2', 'is_dependent': False},
+                DBObject('owner3', 'mytable7'): {'owner': 'owner2', 'is_dependent': False},
             },
         },
         'sequences': {
             'schema1': {
-                quoted_object('schema1', 'myseq1'): {'owner': 'owner2', 'is_dependent': False},
-                quoted_object('schema1', 'myseq2'): {'owner': 'owner3', 'is_dependent': True},
+                DBObject('schema1', 'myseq1'): {'owner': 'owner2', 'is_dependent': False},
+                DBObject('schema1', 'myseq2'): {'owner': 'owner3', 'is_dependent': True},
             },
             'schema2': {
-                quoted_object('schema2', 'myseq3'): {'owner': 'owner1', 'is_dependent': False},
-                quoted_object('schema2', 'myseq4'): {'owner': 'owner2', 'is_dependent': False},
+                DBObject('schema2', 'myseq3'): {'owner': 'owner1', 'is_dependent': False},
+                DBObject('schema2', 'myseq4'): {'owner': 'owner2', 'is_dependent': False},
             },
         },
     }
@@ -259,18 +256,12 @@ def test_add_ownerships(mockdbcontext):
     assert actual['owner3'] == {'has_personal_schema': True}
 
     # Table ownership assertions
-    assert set(actual['owner1']['owns']['tables']) == set([
-        quoted_object('schema1', 'mytable1'),
-        'schema2.*',
-    ])
-    assert actual['owner2']['owns']['tables'] == [quoted_object('schema1', 'mytable3')]
+    assert set(actual['owner1']['owns']['tables']) == set(['schema1."mytable1"', 'schema2."*"'])
+    assert actual['owner2']['owns']['tables'] == ['schema1."mytable3"']
 
     # Sequence ownership assertions
-    assert actual['owner1']['owns']['sequences'] == [quoted_object('schema2', 'myseq3')]
-    assert set(actual['owner2']['owns']['sequences']) == set([
-        'schema1.*',
-        quoted_object('schema2', 'myseq4')
-    ])
+    assert actual['owner1']['owns']['sequences'] == ['schema2."myseq3"']
+    assert set(actual['owner2']['owns']['sequences']) == set(['schema1."*"', 'schema2."myseq4"'])
 
 
 @run_setup_sql([

--- a/tests/test_core_generate.py
+++ b/tests/test_core_generate.py
@@ -439,8 +439,8 @@ def test_determine_schema_privileges_both_read_and_write_no_personal_schemas(cur
     dbcontext = DatabaseContext(cursor, verbose=True)
     actual = core_generate.determine_schema_privileges('role0', dbcontext)
     expected = {
-        'write': ['schema2', 'schema3'],
-        'read': ['schema0', 'schema1'],
+        'write': set([DBObject('schema2'), DBObject('schema3')]),
+        'read': set([DBObject('schema0'), DBObject('schema1')]),
     }
     assert actual == expected
 
@@ -470,7 +470,7 @@ def test_determine_schema_privileges_only_read_exists(cursor):
     dbcontext = DatabaseContext(cursor, verbose=True)
     actual = core_generate.determine_schema_privileges('role0', dbcontext)
     expected = {
-        'read': ['schema0'],
+        'read': set([DBObject('schema0')]),
     }
     assert actual == expected
 
@@ -510,8 +510,8 @@ def test_determine_schema_privileges_personal_schemas(cursor):
     dbcontext = DatabaseContext(cursor, verbose=True)
     actual = core_generate.determine_schema_privileges('role0', dbcontext)
     expected = {
-        'write': ['schema1'],
-        'read': ['personal_schemas', 'schema0'],
+        'write': set([DBObject('schema1')]),
+        'read': set([DBObject('personal_schemas'), DBObject('schema0')]),
     }
     assert actual == expected
 
@@ -533,7 +533,7 @@ def test_determine_schema_privileges_only_write_exists(cursor):
     dbcontext = DatabaseContext(cursor, verbose=True)
     actual = core_generate.determine_schema_privileges('role0', dbcontext)
     expected = {
-        'write': ['schema0', 'schema1'],
+        'write': set([DBObject('schema0'), DBObject('schema1')]),
     }
     assert actual == expected
 

--- a/tests/test_core_generate.py
+++ b/tests/test_core_generate.py
@@ -566,7 +566,8 @@ def test_determine_schema_privileges_has_personal_schema(cursor):
 def test_determine_nonschema_privileges_for_schema_no_objects_with_default_priv(cursor):
     dbcontext = DatabaseContext(cursor, verbose=True)
     actw, actr = core_generate.determine_nonschema_privileges_for_schema('role0', 'tables',
-                                                                         'schema0', dbcontext)
+                                                                         DBObject('schema0'),
+                                                                         dbcontext)
     assert actw == set()
     assert actr == set([DBObject(schema='schema0', object_name='*')])
 
@@ -582,7 +583,8 @@ def test_determine_nonschema_privileges_for_schema_no_objects_with_default_priv(
 def test_determine_nonschema_privileges_for_schema_no_objects(cursor):
     dbcontext = DatabaseContext(cursor, verbose=True)
     actw, actr = core_generate.determine_nonschema_privileges_for_schema('role0', 'tables',
-                                                                         'schema0', dbcontext)
+                                                                         DBObject('schema0'),
+                                                                         dbcontext)
     assert actw == set()
     assert actr == set()
 
@@ -604,7 +606,8 @@ def test_determine_nonschema_privileges_for_schema_no_objects(cursor):
 def test_determine_nonschema_privileges_for_schema_default_write(cursor):
     dbcontext = DatabaseContext(cursor, verbose=True)
     actw, actr = core_generate.determine_nonschema_privileges_for_schema('role0', 'tables',
-                                                                         'schema0', dbcontext)
+                                                                         DBObject('schema0'),
+                                                                         dbcontext)
     assert actw == set([DBObject(schema='schema0', object_name='*')])
     assert actr == set()
 
@@ -626,7 +629,8 @@ def test_determine_nonschema_privileges_for_schema_default_write(cursor):
 def test_determine_nonschema_privileges_for_schema_has_all_writes(cursor):
     dbcontext = DatabaseContext(cursor, verbose=True)
     actw, actr = core_generate.determine_nonschema_privileges_for_schema('role0', 'tables',
-                                                                         'schema0', dbcontext)
+                                                                         DBObject('schema0'),
+                                                                         dbcontext)
     assert actw == set([DBObject(schema='schema0', object_name='*')])
     assert actr == set()
 
@@ -650,7 +654,8 @@ def test_determine_nonschema_privileges_for_schema_has_all_writes(cursor):
 def test_determine_nonschema_privileges_for_schema_some_write_default_read(cursor):
     dbcontext = DatabaseContext(cursor, verbose=True)
     actw, actr = core_generate.determine_nonschema_privileges_for_schema('role0', 'tables',
-                                                                         'schema0', dbcontext)
+                                                                         DBObject('schema0'),
+                                                                         dbcontext)
     assert actw == set([DBObject(schema='schema0', object_name='table0')])
     assert actr == set([DBObject(schema='schema0', object_name='*')])
 
@@ -672,7 +677,8 @@ def test_determine_nonschema_privileges_for_schema_some_write_default_read(curso
 def test_determine_nonschema_privileges_for_schema_no_writes_all_reads(cursor):
     dbcontext = DatabaseContext(cursor, verbose=True)
     actw, actr = core_generate.determine_nonschema_privileges_for_schema('role0', 'tables',
-                                                                         'schema0', dbcontext)
+                                                                         DBObject('schema0'),
+                                                                         dbcontext)
     assert actw == set()
     assert actr == set([DBObject(schema='schema0', object_name='*')])
 
@@ -698,7 +704,8 @@ def test_determine_nonschema_privileges_for_schema_no_writes_all_reads(cursor):
 def test_determine_nonschema_privileges_for_schema_some_writes_some_reads(cursor):
     dbcontext = DatabaseContext(cursor, verbose=True)
     actw, actr = core_generate.determine_nonschema_privileges_for_schema('role0', 'tables',
-                                                                         'schema0', dbcontext)
+                                                                         DBObject('schema0'),
+                                                                         dbcontext)
     assert actw == set([
         DBObject(schema='schema0', object_name='table1'),
         DBObject(schema='schema0', object_name='table2'),
@@ -725,7 +732,8 @@ def test_determine_nonschema_privileges_for_schema_some_writes_some_reads(cursor
 def test_determine_nonschema_privileges_for_schema_all_writes(cursor):
     dbcontext = DatabaseContext(cursor, verbose=True)
     actw, actr = core_generate.determine_nonschema_privileges_for_schema('role0', 'tables',
-                                                                         'schema0', dbcontext)
+                                                                         DBObject('schema0'),
+                                                                         dbcontext)
     assert actw == set([DBObject(schema='schema0', object_name='*')])
     assert actr == set()
 
@@ -749,7 +757,8 @@ def test_determine_nonschema_privileges_for_schema_all_writes(cursor):
 def test_determine_nonschema_privileges_for_schema_default_write_some_reads(cursor):
     dbcontext = DatabaseContext(cursor, verbose=True)
     actw, actr = core_generate.determine_nonschema_privileges_for_schema('role0', 'tables',
-                                                                         'schema0', dbcontext)
+                                                                         DBObject('schema0'),
+                                                                         dbcontext)
     assert actw == set([DBObject(schema='schema0', object_name='*')])
     assert actr == set()
 
@@ -769,7 +778,8 @@ def test_determine_nonschema_privileges_for_schema_default_write_some_reads(curs
 def test_determine_nonschema_privileges_for_schema_default_write_and_default_read(cursor):
     dbcontext = DatabaseContext(cursor, verbose=True)
     actw, actr = core_generate.determine_nonschema_privileges_for_schema('role0', 'tables',
-                                                                         'schema0', dbcontext)
+                                                                         DBObject('schema0'),
+                                                                         dbcontext)
     assert actw == set([DBObject(schema='schema0', object_name='*')])
     assert actr == set()
 
@@ -791,7 +801,8 @@ def test_determine_nonschema_privileges_for_schema_default_write_and_default_rea
 def test_determine_nonschema_privileges_for_schema_no_write_all_reads(cursor):
     dbcontext = DatabaseContext(cursor, verbose=True)
     actw, actr = core_generate.determine_nonschema_privileges_for_schema('role0', 'tables',
-                                                                         'schema0', dbcontext)
+                                                                         DBObject('schema0'),
+                                                                         dbcontext)
     assert actw == set()
     assert actr == set([DBObject(schema='schema0', object_name='*')])
 
@@ -812,7 +823,8 @@ def test_determine_nonschema_privileges_for_schema_no_write_all_reads(cursor):
 def test_determine_nonschema_privileges_for_schema_no_writes_some_reads(cursor):
     dbcontext = DatabaseContext(cursor, verbose=True)
     actw, actr = core_generate.determine_nonschema_privileges_for_schema('role0', 'tables',
-                                                                         'schema0', dbcontext)
+                                                                         DBObject('schema0'),
+                                                                         dbcontext)
     assert actw == set()
     assert actr == set([DBObject(schema='schema0', object_name='table0')])
 
@@ -832,7 +844,8 @@ def test_determine_nonschema_privileges_for_schema_no_writes_some_reads(cursor):
 def test_determine_nonschema_privileges_for_schema_no_objects_of_objkind(cursor):
     dbcontext = DatabaseContext(cursor, verbose=True)
     actw, actr = core_generate.determine_nonschema_privileges_for_schema('role0', 'tables',
-                                                                         'schema0', dbcontext)
+                                                                         DBObject('schema0'),
+                                                                         dbcontext)
     assert actw == set()
     assert actr == set()
 

--- a/tests/test_core_generate.py
+++ b/tests/test_core_generate.py
@@ -574,7 +574,7 @@ def test_determine_nonschema_privileges_for_schema_no_objects_with_default_priv(
                                                                          ObjectName('schema0'),
                                                                          dbcontext)
     assert actw == set()
-    assert actr == set([ObjectName(schema='schema0', object_name='*')])
+    assert actr == set([ObjectName('schema0', '*')])
 
 
 @run_setup_sql([
@@ -613,7 +613,7 @@ def test_determine_nonschema_privileges_for_schema_default_write(cursor):
     actw, actr = core_generate.determine_nonschema_privileges_for_schema('role0', 'tables',
                                                                          ObjectName('schema0'),
                                                                          dbcontext)
-    assert actw == set([ObjectName(schema='schema0', object_name='*')])
+    assert actw == set([ObjectName('schema0', '*')])
     assert actr == set()
 
 
@@ -636,7 +636,7 @@ def test_determine_nonschema_privileges_for_schema_has_all_writes(cursor):
     actw, actr = core_generate.determine_nonschema_privileges_for_schema('role0', 'tables',
                                                                          ObjectName('schema0'),
                                                                          dbcontext)
-    assert actw == set([ObjectName(schema='schema0', object_name='*')])
+    assert actw == set([ObjectName('schema0', '*')])
     assert actr == set()
 
 
@@ -661,8 +661,8 @@ def test_determine_nonschema_privileges_for_schema_some_write_default_read(curso
     actw, actr = core_generate.determine_nonschema_privileges_for_schema('role0', 'tables',
                                                                          ObjectName('schema0'),
                                                                          dbcontext)
-    assert actw == set([ObjectName(schema='schema0', object_name='table0')])
-    assert actr == set([ObjectName(schema='schema0', object_name='*')])
+    assert actw == set([ObjectName('schema0', 'table0')])
+    assert actr == set([ObjectName('schema0', '*')])
 
 
 @run_setup_sql([
@@ -685,7 +685,7 @@ def test_determine_nonschema_privileges_for_schema_no_writes_all_reads(cursor):
                                                                          ObjectName('schema0'),
                                                                          dbcontext)
     assert actw == set()
-    assert actr == set([ObjectName(schema='schema0', object_name='*')])
+    assert actr == set([ObjectName('schema0', '*')])
 
 
 @run_setup_sql([
@@ -712,10 +712,10 @@ def test_determine_nonschema_privileges_for_schema_some_writes_some_reads(cursor
                                                                          ObjectName('schema0'),
                                                                          dbcontext)
     assert actw == set([
-        ObjectName(schema='schema0', object_name='table1'),
-        ObjectName(schema='schema0', object_name='table2'),
+        ObjectName('schema0', 'table1'),
+        ObjectName('schema0', 'table2'),
     ])
-    assert actr == set([ObjectName(schema='schema0', object_name='table0')])
+    assert actr == set([ObjectName('schema0', 'table0')])
 
 
 @run_setup_sql([
@@ -739,7 +739,7 @@ def test_determine_nonschema_privileges_for_schema_all_writes(cursor):
     actw, actr = core_generate.determine_nonschema_privileges_for_schema('role0', 'tables',
                                                                          ObjectName('schema0'),
                                                                          dbcontext)
-    assert actw == set([ObjectName(schema='schema0', object_name='*')])
+    assert actw == set([ObjectName('schema0', '*')])
     assert actr == set()
 
 
@@ -764,7 +764,7 @@ def test_determine_nonschema_privileges_for_schema_default_write_some_reads(curs
     actw, actr = core_generate.determine_nonschema_privileges_for_schema('role0', 'tables',
                                                                          ObjectName('schema0'),
                                                                          dbcontext)
-    assert actw == set([ObjectName(schema='schema0', object_name='*')])
+    assert actw == set([ObjectName('schema0', '*')])
     assert actr == set()
 
 
@@ -785,7 +785,7 @@ def test_determine_nonschema_privileges_for_schema_default_write_and_default_rea
     actw, actr = core_generate.determine_nonschema_privileges_for_schema('role0', 'tables',
                                                                          ObjectName('schema0'),
                                                                          dbcontext)
-    assert actw == set([ObjectName(schema='schema0', object_name='*')])
+    assert actw == set([ObjectName('schema0', '*')])
     assert actr == set()
 
 
@@ -809,7 +809,7 @@ def test_determine_nonschema_privileges_for_schema_no_write_all_reads(cursor):
                                                                          ObjectName('schema0'),
                                                                          dbcontext)
     assert actw == set()
-    assert actr == set([ObjectName(schema='schema0', object_name='*')])
+    assert actr == set([ObjectName('schema0', '*')])
 
 
 @run_setup_sql([
@@ -831,7 +831,7 @@ def test_determine_nonschema_privileges_for_schema_no_writes_some_reads(cursor):
                                                                          ObjectName('schema0'),
                                                                          dbcontext)
     assert actw == set()
-    assert actr == set([ObjectName(schema='schema0', object_name='table0')])
+    assert actr == set([ObjectName('schema0', 'table0')])
 
 
 @run_setup_sql([
@@ -884,8 +884,8 @@ def test_determine_nonschema_privileges_for_schema_no_objects_of_objkind(cursor)
 def test_determine_all_nonschema_privileges(cursor):
     dbcontext = DatabaseContext(cursor, verbose=True)
     actw, actr = core_generate.determine_all_nonschema_privileges('role0', 'tables', dbcontext)
-    assert actw == set([ObjectName(schema='schema0', object_name='*')])
-    assert actr == set([ObjectName(schema='schema1', object_name='table3')])
+    assert actw == set([ObjectName('schema0', '*')])
+    assert actr == set([ObjectName('schema1', 'table3')])
 
 
 def test_initialize_spec(mockdbcontext):

--- a/tests/test_core_generate.py
+++ b/tests/test_core_generate.py
@@ -107,15 +107,15 @@ def test_add_memberships(mockdbcontext):
 def test_add_schema_ownerships(mockdbcontext):
     mockdbcontext.get_all_schemas_and_owners = lambda: {
         # Non-personal schemas
-        'schema1': 'owner1',
-        'schema2': 'owner1',
-        'schema3': 'owner2',
+        DBObject('schema1'): 'owner1',
+        DBObject('schema2'): 'owner1',
+        DBObject('schema3'): 'owner2',
 
         # Personal schema
-        'owner1': 'owner1',
+        DBObject('owner1'): 'owner1',
 
         # Would not show up in get_all_personal_schemas as can_login is False
-        'owner2': 'owner2',
+        DBObject('owner2'): 'owner2',
     }
     mockdbcontext.get_all_personal_schemas = lambda: set([DBObject('owner1')])
 
@@ -236,11 +236,11 @@ def test_add_ownerships(mockdbcontext):
     }
     mockdbcontext.get_all_schemas_and_owners = lambda: {
         # Non-personal schemas
-        'schema1': 'owner1',
-        'schema2': 'owner1',
+        DBObject('schema1'): 'owner1',
+        DBObject('schema2'): 'owner1',
 
         # Personal schema
-        'owner3': 'owner3',
+        DBObject('owner3'): 'owner3',
     }
     mockdbcontext.get_all_personal_schemas = lambda: set([DBObject('owner3')])
 

--- a/tests/test_core_generate.py
+++ b/tests/test_core_generate.py
@@ -172,7 +172,7 @@ def test_add_nonschema_ownerships(mockdbcontext):
 
     actual = core_generate.add_nonschema_ownerships(spec, mockdbcontext, 'tables')
     assert actual['owner1']['owns']['schemas'] == ['schema1']
-    assert set(actual['owner1']['owns']['tables']) == set(['schema1."mytable1"', 'schema2."*"'])
+    assert set(actual['owner1']['owns']['tables']) == set(['schema1."mytable1"', 'schema2.*'])
     assert actual['owner2']['owns']['tables'] == ['schema1."mytable3"']
     assert actual['owner3'] == {}
     assert actual['owner4'] == {}
@@ -256,12 +256,12 @@ def test_add_ownerships(mockdbcontext):
     assert actual['owner3'] == {'has_personal_schema': True}
 
     # Table ownership assertions
-    assert set(actual['owner1']['owns']['tables']) == set(['schema1."mytable1"', 'schema2."*"'])
+    assert set(actual['owner1']['owns']['tables']) == set(['schema1."mytable1"', 'schema2.*'])
     assert actual['owner2']['owns']['tables'] == ['schema1."mytable3"']
 
     # Sequence ownership assertions
     assert actual['owner1']['owns']['sequences'] == ['schema2."myseq3"']
-    assert set(actual['owner2']['owns']['sequences']) == set(['schema1."*"', 'schema2."myseq4"'])
+    assert set(actual['owner2']['owns']['sequences']) == set(['schema1.*', 'schema2."myseq4"'])
 
 
 @run_setup_sql([
@@ -404,7 +404,7 @@ def test_add_privileges(cursor):
                     'write': ['schema3'],
                 },
                 'tables': {
-                    'write': ['schema0."*"'],
+                    'write': ['schema0.*'],
                 },
             },
         },

--- a/tests/test_ownerships.py
+++ b/tests/test_ownerships.py
@@ -1,7 +1,7 @@
 from conftest import quoted_object, run_setup_sql
 from pgbedrock import ownerships as own
 from pgbedrock import attributes, privileges
-from pgbedrock.context import ObjectInfo
+from pgbedrock.context import ObjectInfo, DBObject
 
 Q_CREATE_SEQUENCE = 'SET ROLE {}; CREATE SEQUENCE {}.{}; RESET ROLE;'
 Q_CREATE_TABLE = 'SET ROLE {}; CREATE TABLE {}.{} AS (SELECT 1+1); RESET ROLE;'
@@ -183,10 +183,10 @@ def test_schemaanalyzer_existing_schema_same_owner(mockdbcontext):
 def test_schemaanalyzer_existing_personal_schema_change_object_owners(mockdbcontext):
     mockdbcontext.get_schema_owner = lambda x: ROLES[0]
     mockdbcontext.get_schema_objects = lambda x: [
-        ObjectInfo('tables', quoted_object(ROLES[0], TABLES[0]), ROLES[0], False),
-        ObjectInfo('sequences', quoted_object(ROLES[0], SEQUENCES[0]), ROLES[0], False),
-        ObjectInfo('tables', quoted_object(ROLES[0], TABLES[1]), ROLES[1], False),
-        ObjectInfo('sequences', quoted_object(ROLES[0], SEQUENCES[1]), ROLES[1], False),
+        ObjectInfo('tables', DBObject(schema=ROLES[0], object_name=TABLES[0]), ROLES[0], False),
+        ObjectInfo('sequences', DBObject(schema=ROLES[0], object_name=SEQUENCES[0]), ROLES[0], False),
+        ObjectInfo('tables', DBObject(schema=ROLES[0], object_name=TABLES[1]), ROLES[1], False),
+        ObjectInfo('sequences', DBObject(schema=ROLES[0], object_name=SEQUENCES[1]), ROLES[1], False),
     ]
     schema = ROLES[0]
 
@@ -233,15 +233,15 @@ def test_schemaanalyzer_get_improperly_owned_objects(mockdbcontext):
     mockdbcontext.get_schema_owner = lambda x: ROLES[0]
     mockdbcontext.get_schema_objects = lambda x: [
         # Properly owned
-        ObjectInfo('tables', quoted_object(ROLES[0], TABLES[0]), ROLES[0], False),
-        ObjectInfo('sequences', quoted_object(ROLES[0], SEQUENCES[0]), ROLES[0], False),
+        ObjectInfo('tables', DBObject(schema=ROLES[0], object_name=TABLES[0]), ROLES[0], False),
+        ObjectInfo('sequences', DBObject(schema=ROLES[0], object_name=SEQUENCES[0]), ROLES[0], False),
 
         # Improperly owned
-        ObjectInfo('tables', quoted_object(ROLES[0], TABLES[1]), ROLES[1], False),
-        ObjectInfo('sequences', quoted_object(ROLES[0], SEQUENCES[1]), ROLES[1], False),
+        ObjectInfo('tables', DBObject(schema=ROLES[0], object_name=TABLES[1]), ROLES[1], False),
+        ObjectInfo('sequences', DBObject(schema=ROLES[0], object_name=SEQUENCES[1]), ROLES[1], False),
 
         # Improperly owned but dependent (i.e. should be skipped)
-        ObjectInfo('sequences', quoted_object(ROLES[0], SEQUENCES[2]), ROLES[1], True),
+        ObjectInfo('sequences', DBObject(schema=ROLES[0], object_name=SEQUENCES[2]), ROLES[1], True),
     ]
     schema = ROLES[0]
 

--- a/tests/test_ownerships.py
+++ b/tests/test_ownerships.py
@@ -190,10 +190,10 @@ def test_schemaanalyzer_existing_personal_schema_change_object_owners(mockdbcont
     personal_schema = ROLES[0]
     mockdbcontext.get_schema_owner = lambda x: ROLES[0]
     mockdbcontext.get_schema_objects = lambda x: [
-        ObjectInfo('tables', ObjectName(schema=personal_schema, object_name=TABLES[0]), ROLES[0], False),
-        ObjectInfo('sequences', ObjectName(schema=personal_schema, object_name=SEQUENCES[0]), ROLES[0], False),
-        ObjectInfo('tables', ObjectName(schema=personal_schema, object_name=TABLES[1]), ROLES[1], False),
-        ObjectInfo('sequences', ObjectName(schema=personal_schema, object_name=SEQUENCES[1]), ROLES[1], False),
+        ObjectInfo('tables', ObjectName(personal_schema, TABLES[0]), ROLES[0], False),
+        ObjectInfo('sequences', ObjectName(personal_schema, SEQUENCES[0]), ROLES[0], False),
+        ObjectInfo('tables', ObjectName(personal_schema, TABLES[1]), ROLES[1], False),
+        ObjectInfo('sequences', ObjectName(personal_schema, SEQUENCES[1]), ROLES[1], False),
     ]
     schemaconf = own.SchemaAnalyzer(ROLES[0], objname=ObjectName(personal_schema),
                                     dbcontext=mockdbcontext, is_personal_schema=True)
@@ -226,7 +226,7 @@ def test_schemaanalyzer_alter_object_owner(mockdbcontext):
     previous_owner = ROLES[1]
     owner = ROLES[0]
     schema = SCHEMAS[0]
-    objname = ObjectName(schema=schema, object_name=TABLES[0])
+    objname = ObjectName(schema, TABLES[0])
     mockdbcontext.get_schema_owner = lambda x: owner
 
     schemaconf = own.SchemaAnalyzer(owner, objname=ObjectName(schema), dbcontext=mockdbcontext)
@@ -242,22 +242,22 @@ def test_schemaanalyzer_get_improperly_owned_objects(mockdbcontext):
     mockdbcontext.get_schema_owner = lambda x: owner
     mockdbcontext.get_schema_objects = lambda x: [
         # Properly owned
-        ObjectInfo('tables', ObjectName(schema=owner, object_name=TABLES[0]), owner, False),
-        ObjectInfo('sequences', ObjectName(schema=owner, object_name=SEQUENCES[0]), owner, False),
+        ObjectInfo('tables', ObjectName(owner, TABLES[0]), owner, False),
+        ObjectInfo('sequences', ObjectName(owner, SEQUENCES[0]), owner, False),
 
         # Improperly owned
-        ObjectInfo('tables', ObjectName(schema=owner, object_name=TABLES[1]), wrong_owner, False),
-        ObjectInfo('sequences', ObjectName(schema=owner, object_name=SEQUENCES[1]), wrong_owner, False),
+        ObjectInfo('tables', ObjectName(owner, TABLES[1]), wrong_owner, False),
+        ObjectInfo('sequences', ObjectName(owner, SEQUENCES[1]), wrong_owner, False),
 
         # Improperly owned but dependent (i.e. should be skipped)
-        ObjectInfo('sequences', ObjectName(schema=owner, object_name=SEQUENCES[2]), wrong_owner, True),
+        ObjectInfo('sequences', ObjectName(owner, SEQUENCES[2]), wrong_owner, True),
     ]
     schemaconf = own.SchemaAnalyzer(rolename=owner, objname=ObjectName(owner),
                                     dbcontext=mockdbcontext, is_personal_schema=True)
 
     actual = schemaconf.get_improperly_owned_objects()
-    expected = [('tables', ObjectName(schema=owner, object_name=TABLES[1]), wrong_owner),
-                ('sequences', ObjectName(schema=owner, object_name=SEQUENCES[1]), wrong_owner)]
+    expected = [('tables', ObjectName(owner, TABLES[1]), wrong_owner),
+                ('sequences', ObjectName(owner, SEQUENCES[1]), wrong_owner)]
     assert set(actual) == set(expected)
 
 

--- a/tests/test_ownerships.py
+++ b/tests/test_ownerships.py
@@ -266,7 +266,7 @@ def test_nonschemaanalyzer_expand_schema_objects(mockdbcontext):
             },
         },
     }
-    nsa = own.NonschemaAnalyzer(rolename=ROLES[0], objname=DUMMY,
+    nsa = own.NonschemaAnalyzer(rolename=ROLES[0], dbobject=DUMMY,
                                 objkind='tables', dbcontext=mockdbcontext)
     actual = nsa.expand_schema_objects(SCHEMAS[0])
     expected = [DBObject(SCHEMAS[0], TABLES[0]), DBObject(SCHEMAS[0], TABLES[1])]
@@ -274,35 +274,33 @@ def test_nonschemaanalyzer_expand_schema_objects(mockdbcontext):
 
 
 def test_nonschemaanalyzer_analyze_no_changed_needed(mockdbcontext):
-    objname = quoted_object(SCHEMAS[0], TABLES[0])
-    dbo = DBObject(SCHEMAS[0], TABLES[0])
+    dbobject = DBObject(SCHEMAS[0], TABLES[0])
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             SCHEMAS[0]: {
-                dbo: {'owner': ROLES[0], 'is_dependent': False},
+                dbobject: {'owner': ROLES[0], 'is_dependent': False},
             },
         },
     }
-    nsa = own.NonschemaAnalyzer(rolename=ROLES[0], objname=objname,
+    nsa = own.NonschemaAnalyzer(rolename=ROLES[0], dbobject=dbobject,
                                 objkind='tables', dbcontext=mockdbcontext)
     actual = nsa.analyze()
     assert actual == []
 
 
 def test_nonschemaanalyzer_analyze_without_schema_expansion(mockdbcontext):
-    objname = quoted_object(SCHEMAS[0], TABLES[0])
-    dbo = DBObject(SCHEMAS[0], TABLES[0])
+    dbobject = DBObject(SCHEMAS[0], TABLES[0])
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             SCHEMAS[0]: {
-                dbo: {'owner': ROLES[1], 'is_dependent': False},
+                dbobject: {'owner': ROLES[1], 'is_dependent': False},
             },
         },
     }
-    nsa = own.NonschemaAnalyzer(rolename=ROLES[0], objname=objname,
+    nsa = own.NonschemaAnalyzer(rolename=ROLES[0], dbobject=dbobject,
                                 objkind='tables', dbcontext=mockdbcontext)
     actual = nsa.analyze()
-    expected = [own.Q_SET_OBJECT_OWNER.format('TABLE', objname, ROLES[0], ROLES[1])]
+    expected = [own.Q_SET_OBJECT_OWNER.format('TABLE', dbobject.qualified_name, ROLES[0], ROLES[1])]
     assert actual == expected
 
 
@@ -319,7 +317,7 @@ def test_nonschemaanalyzer_analyze_with_schema_expansion(mockdbcontext):
             },
         },
     }
-    nsa = own.NonschemaAnalyzer(rolename=ROLES[0], objname='{}.*'.format(SCHEMAS[0]),
+    nsa = own.NonschemaAnalyzer(rolename=ROLES[0], dbobject=DBObject(SCHEMAS[0], '*'),
                                 objkind='sequences', dbcontext=mockdbcontext)
     actual = nsa.analyze()
     expected = [

--- a/tests/test_ownerships.py
+++ b/tests/test_ownerships.py
@@ -260,25 +260,26 @@ def test_nonschemaanalyzer_expand_schema_objects(mockdbcontext):
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             SCHEMAS[0]: {
-                quoted_object(SCHEMAS[0], TABLES[0]): {'owner': DUMMY, 'is_dependent': False},
-                quoted_object(SCHEMAS[0], TABLES[1]): {'owner': DUMMY, 'is_dependent': False},
-                quoted_object(SCHEMAS[0], TABLES[2]): {'owner': DUMMY, 'is_dependent': True},
+                DBObject(SCHEMAS[0], TABLES[0]): {'owner': DUMMY, 'is_dependent': False},
+                DBObject(SCHEMAS[0], TABLES[1]): {'owner': DUMMY, 'is_dependent': False},
+                DBObject(SCHEMAS[0], TABLES[2]): {'owner': DUMMY, 'is_dependent': True},
             },
         },
     }
     nsa = own.NonschemaAnalyzer(rolename=ROLES[0], objname=DUMMY,
                                 objkind='tables', dbcontext=mockdbcontext)
     actual = nsa.expand_schema_objects(SCHEMAS[0])
-    expected = [quoted_object(SCHEMAS[0], TABLES[0]), quoted_object(SCHEMAS[0], TABLES[1])]
+    expected = [DBObject(SCHEMAS[0], TABLES[0]), DBObject(SCHEMAS[0], TABLES[1])]
     assert set(actual) == set(expected)
 
 
 def test_nonschemaanalyzer_analyze_no_changed_needed(mockdbcontext):
     objname = quoted_object(SCHEMAS[0], TABLES[0])
+    dbo = DBObject(SCHEMAS[0], TABLES[0])
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             SCHEMAS[0]: {
-                objname: {'owner': ROLES[0], 'is_dependent': False},
+                dbo: {'owner': ROLES[0], 'is_dependent': False},
             },
         },
     }
@@ -290,10 +291,11 @@ def test_nonschemaanalyzer_analyze_no_changed_needed(mockdbcontext):
 
 def test_nonschemaanalyzer_analyze_without_schema_expansion(mockdbcontext):
     objname = quoted_object(SCHEMAS[0], TABLES[0])
+    dbo = DBObject(SCHEMAS[0], TABLES[0])
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             SCHEMAS[0]: {
-                objname: {'owner': ROLES[1], 'is_dependent': False},
+                dbo: {'owner': ROLES[1], 'is_dependent': False},
             },
         },
     }
@@ -308,12 +310,12 @@ def test_nonschemaanalyzer_analyze_with_schema_expansion(mockdbcontext):
     mockdbcontext.get_all_object_attributes = lambda: {
         'sequences': {
             SCHEMAS[0]: {
-                quoted_object(SCHEMAS[0], SEQUENCES[0]): {'owner': ROLES[1], 'is_dependent': False},
-                quoted_object(SCHEMAS[0], SEQUENCES[1]): {'owner': ROLES[2], 'is_dependent': False},
+                DBObject(SCHEMAS[0], SEQUENCES[0]): {'owner': ROLES[1], 'is_dependent': False},
+                DBObject(SCHEMAS[0], SEQUENCES[1]): {'owner': ROLES[2], 'is_dependent': False},
                 # This will be skipped as the owner is correct
-                quoted_object(SCHEMAS[0], SEQUENCES[2]): {'owner': ROLES[0], 'is_dependent': False},
+                DBObject(SCHEMAS[0], SEQUENCES[2]): {'owner': ROLES[0], 'is_dependent': False},
                 # This will be skipped as it is dependent
-                quoted_object(SCHEMAS[0], SEQUENCES[3]): {'owner': ROLES[1], 'is_dependent': True},
+                DBObject(SCHEMAS[0], SEQUENCES[3]): {'owner': ROLES[1], 'is_dependent': True},
             },
         },
     }
@@ -321,9 +323,9 @@ def test_nonschemaanalyzer_analyze_with_schema_expansion(mockdbcontext):
                                 objkind='sequences', dbcontext=mockdbcontext)
     actual = nsa.analyze()
     expected = [
-        own.Q_SET_OBJECT_OWNER.format('SEQUENCE', quoted_object(SCHEMAS[0], SEQUENCES[0]),
+        own.Q_SET_OBJECT_OWNER.format('SEQUENCE', DBObject(SCHEMAS[0], SEQUENCES[0]).qualified_name,
                                       ROLES[0], ROLES[1]),
-        own.Q_SET_OBJECT_OWNER.format('SEQUENCE', quoted_object(SCHEMAS[0], SEQUENCES[1]),
+        own.Q_SET_OBJECT_OWNER.format('SEQUENCE', DBObject(SCHEMAS[0], SEQUENCES[1]).qualified_name,
                                       ROLES[0], ROLES[2]),
     ]
     assert set(actual) == set(expected)

--- a/tests/test_ownerships.py
+++ b/tests/test_ownerships.py
@@ -25,12 +25,12 @@ def test_analyze_ownerships_create_schemas(cursor):
         ROLES[0]: {
             'has_personal_schema': True,
             'owns': {
-                'schemas': [SCHEMAS[0]]
+                'schemas': [ObjectName(SCHEMAS[0])]
             },
         },
         ROLES[1]: {
             'owns': {
-                'schemas': [SCHEMAS[1]],
+                'schemas': [ObjectName(SCHEMAS[1])],
             },
         },
     }
@@ -67,14 +67,14 @@ def test_analyze_ownerships_nonschemas(cursor):
     spec = {
         ROLES[0]: {
             'owns': {
-                'tables': ['{}.*'.format(SCHEMAS[0])]
+                'tables': [ObjectName(SCHEMAS[0], '*')]
             },
         },
         ROLES[1]: {
             'owns': {
                 'sequences': [
-                    quoted_object(SCHEMAS[1], SEQUENCES[0]),
-                    quoted_object(SCHEMAS[1], SEQUENCES[1]),
+                    ObjectName(SCHEMAS[1], SEQUENCES[0]),
+                    ObjectName(SCHEMAS[1], SEQUENCES[1]),
                 ]
             },
         },
@@ -120,15 +120,15 @@ def test_analyze_ownerships_schemas_and_nonschemas(cursor):
         ROLES[0]: {
             'has_personal_schema': True,
             'owns': {
-                'tables': ['{}.*'.format(SCHEMAS[0])],
-                'schemas': [SCHEMAS[2]],
+                'tables': [ObjectName(SCHEMAS[0], '*')],
+                'schemas': [ObjectName(SCHEMAS[2])],
             },
         },
         ROLES[1]: {
             'owns': {
                 'sequences': [
-                    quoted_object(SCHEMAS[1], SEQUENCES[0]),
-                    quoted_object(SCHEMAS[1], SEQUENCES[1]),
+                    ObjectName(SCHEMAS[1], SEQUENCES[0]),
+                    ObjectName(SCHEMAS[1], SEQUENCES[1]),
                 ]
             },
         },

--- a/tests/test_ownerships.py
+++ b/tests/test_ownerships.py
@@ -221,12 +221,14 @@ def test_schemaanalyzer_alter_object_owner(mockdbcontext):
     previous_owner = ROLES[1]
     owner = ROLES[0]
     schema = SCHEMAS[0]
-    table_name = quoted_object(schema, TABLES[0])
+    dbobject = DBObject(schema=schema, object_name=TABLES[0])
     mockdbcontext.get_schema_owner = lambda x: owner
 
     schemaconf = own.SchemaAnalyzer(owner, schema=schema, dbcontext=mockdbcontext)
-    schemaconf.alter_object_owner('tables', table_name, previous_owner)
-    assert schemaconf.sql_to_run == [own.Q_SET_OBJECT_OWNER.format('TABLE', table_name, owner, previous_owner)]
+    schemaconf.alter_object_owner('tables', dbobject, previous_owner)
+    assert schemaconf.sql_to_run == [
+        own.Q_SET_OBJECT_OWNER.format('TABLE', dbobject.qualified_name, owner, previous_owner)
+    ]
 
 
 def test_schemaanalyzer_get_improperly_owned_objects(mockdbcontext):
@@ -249,8 +251,8 @@ def test_schemaanalyzer_get_improperly_owned_objects(mockdbcontext):
                                     is_personal_schema=True)
 
     actual = schemaconf.get_improperly_owned_objects()
-    expected = [('tables', quoted_object(schema, TABLES[1]), ROLES[1]),
-                ('sequences', quoted_object(schema, SEQUENCES[1]), ROLES[1])]
+    expected = [('tables', DBObject(schema=schema, object_name=TABLES[1]), ROLES[1]),
+                ('sequences', DBObject(schema=schema, object_name=SEQUENCES[1]), ROLES[1])]
     assert set(actual) == set(expected)
 
 

--- a/tests/test_privileges.py
+++ b/tests/test_privileges.py
@@ -647,8 +647,8 @@ def test_analyze_nondefaults(mockdbcontext):
         - schema1.table3 (owned by role3) - GRANTED           --> REVOKE
     """
     mockdbcontext.get_role_current_nondefaults = lambda x, y, z: set([
-        (ObjectName(schema=SCHEMAS[0], object_name=TABLES[1]), 'SELECT'),
-        (ObjectName(schema=SCHEMAS[1], object_name=TABLES[3]), 'SELECT'),
+        (ObjectName(SCHEMAS[0], TABLES[1]), 'SELECT'),
+        (ObjectName(SCHEMAS[1], TABLES[3]), 'SELECT'),
     ])
     mockdbcontext.get_all_object_attributes = lambda: {
         'schemas': {

--- a/tests/test_privileges.py
+++ b/tests/test_privileges.py
@@ -560,7 +560,7 @@ def test_revoke_default(mockdbcontext):
 
 
 def test_grant_nondefault(mockdbcontext):
-    table = quoted_object(SCHEMAS[0], TABLES[0])
+    table = ObjectName(SCHEMAS[0], TABLES[0])
     rolename = ROLES[0]
 
     # Grant the privilege
@@ -569,12 +569,12 @@ def test_grant_nondefault(mockdbcontext):
                                        personal_schemas=DUMMY, dbcontext=mockdbcontext)
 
     privconf.grant_nondefault(table, 'SELECT')
-    expected = [privs.Q_GRANT_NONDEFAULT.format('SELECT', 'TABLE', table, rolename)]
+    expected = [privs.Q_GRANT_NONDEFAULT.format('SELECT', 'TABLE', table.qualified_name, rolename)]
     assert privconf.sql_to_run == expected
 
 
 def test_revoke_nondefault(mockdbcontext):
-    table = quoted_object(SCHEMAS[0], TABLES[0])
+    table = ObjectName(SCHEMAS[0], TABLES[0])
     rolename = ROLES[0]
 
     # Revoke the privilege
@@ -583,7 +583,7 @@ def test_revoke_nondefault(mockdbcontext):
                                        personal_schemas=DUMMY, dbcontext=mockdbcontext)
 
     privconf.revoke_nondefault(table, 'SELECT')
-    expected = [privs.Q_REVOKE_NONDEFAULT.format('SELECT', 'TABLE', table, rolename)]
+    expected = [privs.Q_REVOKE_NONDEFAULT.format('SELECT', 'TABLE', table.qualified_name, rolename)]
     assert privconf.sql_to_run == expected
 
 

--- a/tests/test_privileges.py
+++ b/tests/test_privileges.py
@@ -12,7 +12,7 @@ import yaml
 
 from conftest import quoted_object, run_setup_sql
 from pgbedrock import privileges as privs, attributes, ownerships
-from pgbedrock.context import DBObject
+from pgbedrock.common import ObjectName
 
 
 Q_CREATE_TABLE = 'SET ROLE {}; CREATE TABLE {}.{} AS (SELECT 1+1); RESET ROLE;'
@@ -237,7 +237,7 @@ def test_init_default_acl_possible(object_kind, mockdbcontext):
 
 def test_get_schema_objects_tables(mockdbcontext):
     objattributes = {'owner': ROLES[0], 'is_dependent': False}
-    all_attributes = {DBObject(SCHEMAS[0], t): objattributes for t in TABLES}
+    all_attributes = {ObjectName(SCHEMAS[0], t): objattributes for t in TABLES}
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             SCHEMAS[0]: all_attributes
@@ -258,7 +258,7 @@ def test_get_schema_objects_sequences(mockdbcontext):
     """ While this test is almost identical to test_get_schema_objects_tables(), it's here because
     we want to ensure we have coverage over more than just tables """
     objattributes = {'owner': ROLES[0], 'is_dependent': False}
-    all_attributes = {DBObject(SCHEMAS[0], seq): objattributes for seq in SEQUENCES}
+    all_attributes = {ObjectName(SCHEMAS[0], seq): objattributes for seq in SEQUENCES}
     mockdbcontext.get_all_object_attributes = lambda: {
         'sequences': {
             SCHEMAS[0]: all_attributes
@@ -283,15 +283,15 @@ def test_get_object_owner(mockdbcontext, object_kind, item, expected):
     mockdbcontext.get_all_object_attributes = lambda: {
         'schemas': {
             SCHEMAS[0]: {
-                DBObject(SCHEMAS[0]): {'owner': ROLES[0], 'is_dependent': False},
+                ObjectName(SCHEMAS[0]): {'owner': ROLES[0], 'is_dependent': False},
             },
         }, 'sequences': {
             SCHEMAS[0]: {
-                DBObject(SCHEMAS[0], SEQUENCES[0]): {'owner': ROLES[1], 'is_dependent': False},
+                ObjectName(SCHEMAS[0], SEQUENCES[0]): {'owner': ROLES[1], 'is_dependent': False},
             },
         }, 'tables': {
             SCHEMAS[0]: {
-                DBObject(SCHEMAS[0], TABLES[1]): {'owner': ROLES[2], 'is_dependent': False},
+                ObjectName(SCHEMAS[0], TABLES[1]): {'owner': ROLES[2], 'is_dependent': False},
             },
         },
     }
@@ -322,7 +322,7 @@ def test_get_schema_owner(mockdbcontext):
     mockdbcontext.get_all_object_attributes = lambda: {
         'schemas': {
             SCHEMAS[0]: {
-                DBObject(SCHEMAS[0]): {'owner': ROLES[1], 'is_dependent': False},
+                ObjectName(SCHEMAS[0]): {'owner': ROLES[1], 'is_dependent': False},
             },
         },
     }
@@ -374,17 +374,17 @@ def test_identify_desired_objects(rolename, mockdbcontext):
     mockdbcontext.get_all_object_attributes = lambda: {
         'sequences': {
             SCHEMAS[0]: {
-                DBObject(SCHEMAS[0], SEQUENCES[0]): {'owner': ROLES[1], 'is_dependent': False},
-                DBObject(SCHEMAS[0], SEQUENCES[1]): {'owner': ROLES[2], 'is_dependent': False},
-                DBObject(SCHEMAS[0], SEQUENCES[2]): {'owner': ROLES[2], 'is_dependent': False},
+                ObjectName(SCHEMAS[0], SEQUENCES[0]): {'owner': ROLES[1], 'is_dependent': False},
+                ObjectName(SCHEMAS[0], SEQUENCES[1]): {'owner': ROLES[2], 'is_dependent': False},
+                ObjectName(SCHEMAS[0], SEQUENCES[2]): {'owner': ROLES[2], 'is_dependent': False},
             }, SCHEMAS[1]: {
-                DBObject(SCHEMAS[1], SEQUENCES[0]): {'owner': ROLES[2], 'is_dependent': False},
-                DBObject(SCHEMAS[1], SEQUENCES[1]): {'owner': ROLES[1], 'is_dependent': False},
+                ObjectName(SCHEMAS[1], SEQUENCES[0]): {'owner': ROLES[2], 'is_dependent': False},
+                ObjectName(SCHEMAS[1], SEQUENCES[1]): {'owner': ROLES[1], 'is_dependent': False},
             },
         },
         'schemas': {
-            SCHEMAS[0]: {DBObject(SCHEMAS[0]): {'owner': ROLES[0]}, 'is_dependent': False},
-            SCHEMAS[1]: {DBObject(SCHEMAS[1]): {'owner': ROLES[0]}, 'is_dependent': False},
+            SCHEMAS[0]: {ObjectName(SCHEMAS[0]): {'owner': ROLES[0]}, 'is_dependent': False},
+            SCHEMAS[1]: {ObjectName(SCHEMAS[1]): {'owner': ROLES[0]}, 'is_dependent': False},
         },
     }
 
@@ -436,8 +436,8 @@ def test_identify_desired_objects_personal_schemas_object_kind_is_schema(mockdbc
     that the personal schemas do show up """
     mockdbcontext.get_all_object_attributes = lambda: {
         'schemas': {
-            SCHEMAS[0]: {DBObject(SCHEMAS[0]): {'owner': ROLES[0]}, 'is_dependent': False},
-            SCHEMAS[1]: {DBObject(SCHEMAS[1]): {'owner': ROLES[0]}, 'is_dependent': False},
+            SCHEMAS[0]: {ObjectName(SCHEMAS[0]): {'owner': ROLES[0]}, 'is_dependent': False},
+            SCHEMAS[1]: {ObjectName(SCHEMAS[1]): {'owner': ROLES[0]}, 'is_dependent': False},
         },
     }
     personal_schemas = ROLES[1:3]
@@ -463,25 +463,25 @@ def test_identify_desired_objects_personal_schemas_object_kind_is_not_schema(moc
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             SCHEMAS[0]: {
-                DBObject(SCHEMAS[0], TABLES[0]): {'owner': ROLES[1], 'is_dependent': False},
+                ObjectName(SCHEMAS[0], TABLES[0]): {'owner': ROLES[1], 'is_dependent': False},
             },
             ROLES[2]: {
-                DBObject(ROLES[2], TABLES[2]): {'owner': ROLES[2], 'is_dependent': False},
-                DBObject(ROLES[2], TABLES[3]): {'owner': ROLES[2], 'is_dependent': False},
+                ObjectName(ROLES[2], TABLES[2]): {'owner': ROLES[2], 'is_dependent': False},
+                ObjectName(ROLES[2], TABLES[3]): {'owner': ROLES[2], 'is_dependent': False},
             },
             ROLES[3]: {
-                DBObject(ROLES[3], TABLES[4]): {'owner': ROLES[3], 'is_dependent': False},
-                DBObject(ROLES[3], TABLES[5]): {'owner': ROLES[3], 'is_dependent': False},
+                ObjectName(ROLES[3], TABLES[4]): {'owner': ROLES[3], 'is_dependent': False},
+                ObjectName(ROLES[3], TABLES[5]): {'owner': ROLES[3], 'is_dependent': False},
             },
         }, 'schemas': {
             SCHEMAS[0]: {
-                DBObject(SCHEMAS[0]): {'owner': ROLES[1]}, 'is_dependent': False
+                ObjectName(SCHEMAS[0]): {'owner': ROLES[1]}, 'is_dependent': False
             },
             ROLES[2]: {
-                DBObject(ROLES[2]): {'owner': ROLES[2]}, 'is_dependent': False
+                ObjectName(ROLES[2]): {'owner': ROLES[2]}, 'is_dependent': False
             },
             ROLES[3]: {
-                DBObject(ROLES[3]): {'owner': ROLES[3]}, 'is_dependent': False
+                ObjectName(ROLES[3]): {'owner': ROLES[3]}, 'is_dependent': False
             },
         },
     }
@@ -601,12 +601,12 @@ def test_analyze_defaults(mockdbcontext):
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             SCHEMAS[0]: {
-                DBObject(SCHEMAS[0], TABLES[0]): {'owner': ROLES[2], 'is_dependent': False},
+                ObjectName(SCHEMAS[0], TABLES[0]): {'owner': ROLES[2], 'is_dependent': False},
             },
         },
         'schemas': {
             SCHEMAS[0]: {
-                DBObject(SCHEMAS[0]): {'owner': ROLES[1], 'is_dependent': False},
+                ObjectName(SCHEMAS[0]): {'owner': ROLES[1], 'is_dependent': False},
             },
         },
     }
@@ -647,26 +647,26 @@ def test_analyze_nondefaults(mockdbcontext):
         - schema1.table3 (owned by role3) - GRANTED           --> REVOKE
     """
     mockdbcontext.get_role_current_nondefaults = lambda x, y, z: set([
-        (DBObject(schema=SCHEMAS[0], object_name=TABLES[1]), 'SELECT'),
-        (DBObject(schema=SCHEMAS[1], object_name=TABLES[3]), 'SELECT'),
+        (ObjectName(schema=SCHEMAS[0], object_name=TABLES[1]), 'SELECT'),
+        (ObjectName(schema=SCHEMAS[1], object_name=TABLES[3]), 'SELECT'),
     ])
     mockdbcontext.get_all_object_attributes = lambda: {
         'schemas': {
             SCHEMAS[0]: {
-                DBObject(SCHEMAS[0]): {'owner': ROLES[1], 'is_dependent': False}
+                ObjectName(SCHEMAS[0]): {'owner': ROLES[1], 'is_dependent': False}
             },
             SCHEMAS[1]: {
-                DBObject(SCHEMAS[1]): {'owner': ROLES[1], 'is_dependent': False}
+                ObjectName(SCHEMAS[1]): {'owner': ROLES[1], 'is_dependent': False}
             },
         },
         'tables': {
             SCHEMAS[0]: {
-                DBObject(SCHEMAS[0], TABLES[0]): {'owner': ROLES[2], 'is_dependent': False},
-                DBObject(SCHEMAS[0], TABLES[1]): {'owner': ROLES[3], 'is_dependent': False},
+                ObjectName(SCHEMAS[0], TABLES[0]): {'owner': ROLES[2], 'is_dependent': False},
+                ObjectName(SCHEMAS[0], TABLES[1]): {'owner': ROLES[3], 'is_dependent': False},
             },
             SCHEMAS[1]: {
-                DBObject(SCHEMAS[1], TABLES[2]): {'owner': ROLES[2], 'is_dependent': False},
-                DBObject(SCHEMAS[1], TABLES[3]): {'owner': ROLES[3], 'is_dependent': False},
+                ObjectName(SCHEMAS[1], TABLES[2]): {'owner': ROLES[2], 'is_dependent': False},
+                ObjectName(SCHEMAS[1], TABLES[3]): {'owner': ROLES[3], 'is_dependent': False},
             },
         }
     }

--- a/tests/test_privileges.py
+++ b/tests/test_privileges.py
@@ -589,7 +589,7 @@ def test_revoke_nondefault(mockdbcontext):
 
 def test_analyze_defaults(mockdbcontext):
     mockdbcontext.get_role_current_defaults = lambda x, y, z: set([
-        (ROLES[3], SCHEMAS[0], 'SELECT'),
+        (ROLES[3], ObjectName(SCHEMAS[0]), 'SELECT'),
     ])
     mockdbcontext.get_role_current_nondefaults = lambda x, y, z: set()
     mockdbcontext.get_all_object_attributes = lambda: {

--- a/tests/test_privileges.py
+++ b/tests/test_privileges.py
@@ -237,7 +237,7 @@ def test_init_default_acl_possible(object_kind, mockdbcontext):
 
 def test_get_schema_objects_tables(mockdbcontext):
     objattributes = {'owner': ROLES[0], 'is_dependent': False}
-    all_attributes = {quoted_object(SCHEMAS[0], t): objattributes for t in TABLES}
+    all_attributes = {DBObject(SCHEMAS[0], t): objattributes for t in TABLES}
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             SCHEMAS[0]: all_attributes
@@ -258,7 +258,7 @@ def test_get_schema_objects_sequences(mockdbcontext):
     """ While this test is almost identical to test_get_schema_objects_tables(), it's here because
     we want to ensure we have coverage over more than just tables """
     objattributes = {'owner': ROLES[0], 'is_dependent': False}
-    all_attributes = {quoted_object(SCHEMAS[0], seq): objattributes for seq in SEQUENCES}
+    all_attributes = {DBObject(SCHEMAS[0], seq): objattributes for seq in SEQUENCES}
     mockdbcontext.get_all_object_attributes = lambda: {
         'sequences': {
             SCHEMAS[0]: all_attributes
@@ -283,15 +283,15 @@ def test_get_object_owner(mockdbcontext, object_kind, item, expected):
     mockdbcontext.get_all_object_attributes = lambda: {
         'schemas': {
             SCHEMAS[0]: {
-                SCHEMAS[0]: {'owner': ROLES[0], 'is_dependent': False},
+                DBObject(SCHEMAS[0]): {'owner': ROLES[0], 'is_dependent': False},
             },
         }, 'sequences': {
             SCHEMAS[0]: {
-                quoted_object(SCHEMAS[0], SEQUENCES[0]): {'owner': ROLES[1], 'is_dependent': False},
+                DBObject(SCHEMAS[0], SEQUENCES[0]): {'owner': ROLES[1], 'is_dependent': False},
             },
         }, 'tables': {
             SCHEMAS[0]: {
-                quoted_object(SCHEMAS[0], TABLES[1]): {'owner': ROLES[2], 'is_dependent': False},
+                DBObject(SCHEMAS[0], TABLES[1]): {'owner': ROLES[2], 'is_dependent': False},
             },
         },
     }
@@ -322,7 +322,7 @@ def test_get_schema_owner(mockdbcontext):
     mockdbcontext.get_all_object_attributes = lambda: {
         'schemas': {
             SCHEMAS[0]: {
-                SCHEMAS[0]: {'owner': ROLES[1], 'is_dependent': False},
+                DBObject(SCHEMAS[0]): {'owner': ROLES[1], 'is_dependent': False},
             },
         },
     }
@@ -374,17 +374,17 @@ def test_identify_desired_objects(rolename, mockdbcontext):
     mockdbcontext.get_all_object_attributes = lambda: {
         'sequences': {
             SCHEMAS[0]: {
-                quoted_object(SCHEMAS[0], SEQUENCES[0]): {'owner': ROLES[1], 'is_dependent': False},
-                quoted_object(SCHEMAS[0], SEQUENCES[1]): {'owner': ROLES[2], 'is_dependent': False},
-                quoted_object(SCHEMAS[0], SEQUENCES[2]): {'owner': ROLES[2], 'is_dependent': False},
+                DBObject(SCHEMAS[0], SEQUENCES[0]): {'owner': ROLES[1], 'is_dependent': False},
+                DBObject(SCHEMAS[0], SEQUENCES[1]): {'owner': ROLES[2], 'is_dependent': False},
+                DBObject(SCHEMAS[0], SEQUENCES[2]): {'owner': ROLES[2], 'is_dependent': False},
             }, SCHEMAS[1]: {
-                quoted_object(SCHEMAS[1], SEQUENCES[0]): {'owner': ROLES[2], 'is_dependent': False},
-                quoted_object(SCHEMAS[1], SEQUENCES[1]): {'owner': ROLES[1], 'is_dependent': False},
+                DBObject(SCHEMAS[1], SEQUENCES[0]): {'owner': ROLES[2], 'is_dependent': False},
+                DBObject(SCHEMAS[1], SEQUENCES[1]): {'owner': ROLES[1], 'is_dependent': False},
             },
         },
         'schemas': {
-            SCHEMAS[0]: {SCHEMAS[0]: {'owner': ROLES[0]}, 'is_dependent': False},
-            SCHEMAS[1]: {SCHEMAS[1]: {'owner': ROLES[0]}, 'is_dependent': False},
+            SCHEMAS[0]: {DBObject(SCHEMAS[0]): {'owner': ROLES[0]}, 'is_dependent': False},
+            SCHEMAS[1]: {DBObject(SCHEMAS[1]): {'owner': ROLES[0]}, 'is_dependent': False},
         },
     }
 
@@ -436,8 +436,8 @@ def test_identify_desired_objects_personal_schemas_object_kind_is_schema(mockdbc
     that the personal schemas do show up """
     mockdbcontext.get_all_object_attributes = lambda: {
         'schemas': {
-            SCHEMAS[0]: {SCHEMAS[0]: {'owner': ROLES[0]}, 'is_dependent': False},
-            SCHEMAS[1]: {SCHEMAS[1]: {'owner': ROLES[0]}, 'is_dependent': False},
+            SCHEMAS[0]: {DBObject(SCHEMAS[0]): {'owner': ROLES[0]}, 'is_dependent': False},
+            SCHEMAS[1]: {DBObject(SCHEMAS[1]): {'owner': ROLES[0]}, 'is_dependent': False},
         },
     }
     personal_schemas = ROLES[1:3]
@@ -463,20 +463,26 @@ def test_identify_desired_objects_personal_schemas_object_kind_is_not_schema(moc
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             SCHEMAS[0]: {
-                quoted_object(SCHEMAS[0], TABLES[0]): {'owner': ROLES[1], 'is_dependent': False},
+                DBObject(SCHEMAS[0], TABLES[0]): {'owner': ROLES[1], 'is_dependent': False},
             },
             ROLES[2]: {
-                quoted_object(ROLES[2], TABLES[2]): {'owner': ROLES[2], 'is_dependent': False},
-                quoted_object(ROLES[2], TABLES[3]): {'owner': ROLES[2], 'is_dependent': False},
+                DBObject(ROLES[2], TABLES[2]): {'owner': ROLES[2], 'is_dependent': False},
+                DBObject(ROLES[2], TABLES[3]): {'owner': ROLES[2], 'is_dependent': False},
             },
             ROLES[3]: {
-                quoted_object(ROLES[3], TABLES[4]): {'owner': ROLES[3], 'is_dependent': False},
-                quoted_object(ROLES[3], TABLES[5]): {'owner': ROLES[3], 'is_dependent': False},
+                DBObject(ROLES[3], TABLES[4]): {'owner': ROLES[3], 'is_dependent': False},
+                DBObject(ROLES[3], TABLES[5]): {'owner': ROLES[3], 'is_dependent': False},
             },
         }, 'schemas': {
-            SCHEMAS[0]: {SCHEMAS[0]: {'owner': ROLES[1]}, 'is_dependent': False},
-            ROLES[2]: {ROLES[2]: {'owner': ROLES[2]}, 'is_dependent': False},
-            ROLES[3]: {ROLES[3]: {'owner': ROLES[3]}, 'is_dependent': False},
+            SCHEMAS[0]: {
+                DBObject(SCHEMAS[0]): {'owner': ROLES[1]}, 'is_dependent': False
+            },
+            ROLES[2]: {
+                DBObject(ROLES[2]): {'owner': ROLES[2]}, 'is_dependent': False
+            },
+            ROLES[3]: {
+                DBObject(ROLES[3]): {'owner': ROLES[3]}, 'is_dependent': False
+            },
         },
     }
     personal_schemas = ROLES[2:4]
@@ -595,12 +601,12 @@ def test_analyze_defaults(mockdbcontext):
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             SCHEMAS[0]: {
-                quoted_object(SCHEMAS[0], TABLES[0]): {'owner': ROLES[2], 'is_dependent': False},
+                DBObject(SCHEMAS[0], TABLES[0]): {'owner': ROLES[2], 'is_dependent': False},
             },
         },
         'schemas': {
             SCHEMAS[0]: {
-                SCHEMAS[0]: {'owner': ROLES[1], 'is_dependent': False},
+                DBObject(SCHEMAS[0]): {'owner': ROLES[1], 'is_dependent': False},
             },
         },
     }
@@ -646,17 +652,21 @@ def test_analyze_nondefaults(mockdbcontext):
     ])
     mockdbcontext.get_all_object_attributes = lambda: {
         'schemas': {
-            SCHEMAS[0]: {SCHEMAS[0]: {'owner': ROLES[1], 'is_dependent': False}},
-            SCHEMAS[1]: {SCHEMAS[1]: {'owner': ROLES[1], 'is_dependent': False}},
+            SCHEMAS[0]: {
+                DBObject(SCHEMAS[0]): {'owner': ROLES[1], 'is_dependent': False}
+            },
+            SCHEMAS[1]: {
+                DBObject(SCHEMAS[1]): {'owner': ROLES[1], 'is_dependent': False}
+            },
         },
         'tables': {
             SCHEMAS[0]: {
-                quoted_object(SCHEMAS[0], TABLES[0]): {'owner': ROLES[2], 'is_dependent': False},
-                quoted_object(SCHEMAS[0], TABLES[1]): {'owner': ROLES[3], 'is_dependent': False},
+                DBObject(SCHEMAS[0], TABLES[0]): {'owner': ROLES[2], 'is_dependent': False},
+                DBObject(SCHEMAS[0], TABLES[1]): {'owner': ROLES[3], 'is_dependent': False},
             },
             SCHEMAS[1]: {
-                quoted_object(SCHEMAS[1], TABLES[2]): {'owner': ROLES[2], 'is_dependent': False},
-                quoted_object(SCHEMAS[1], TABLES[3]): {'owner': ROLES[3], 'is_dependent': False},
+                DBObject(SCHEMAS[1], TABLES[2]): {'owner': ROLES[2], 'is_dependent': False},
+                DBObject(SCHEMAS[1], TABLES[3]): {'owner': ROLES[3], 'is_dependent': False},
             },
         }
     }

--- a/tests/test_privileges.py
+++ b/tests/test_privileges.py
@@ -12,6 +12,7 @@ import yaml
 
 from conftest import quoted_object, run_setup_sql
 from pgbedrock import privileges as privs, attributes, ownerships
+from pgbedrock.context import DBObject
 
 
 Q_CREATE_TABLE = 'SET ROLE {}; CREATE TABLE {}.{} AS (SELECT 1+1); RESET ROLE;'
@@ -640,8 +641,8 @@ def test_analyze_nondefaults(mockdbcontext):
         - schema1.table3 (owned by role3) - GRANTED           --> REVOKE
     """
     mockdbcontext.get_role_current_nondefaults = lambda x, y, z: set([
-        (quoted_object(SCHEMAS[0], TABLES[1]), 'SELECT'),
-        (quoted_object(SCHEMAS[1], TABLES[3]), 'SELECT'),
+        (DBObject(schema=SCHEMAS[0], object_name=TABLES[1]), 'SELECT'),
+        (DBObject(schema=SCHEMAS[1], object_name=TABLES[3]), 'SELECT'),
     ])
     mockdbcontext.get_all_object_attributes = lambda: {
         'schemas': {

--- a/tests/test_privileges.py
+++ b/tests/test_privileges.py
@@ -333,7 +333,7 @@ def test_determine_desired_defaults(mockdbcontext):
                                        desired_items=DUMMY, schema_writers=schema_writers,
                                        personal_schemas=DUMMY, dbcontext=mockdbcontext)
 
-    schemas = [SCHEMAS[0]]
+    schemas = [ObjectName(SCHEMAS[0])]
     roles = ROLES[1:]
     possible_privs = privs.PRIVILEGE_MAP[object_kind][access]
     expected = set(itertools.product(roles, schemas, possible_privs))
@@ -397,7 +397,7 @@ def test_identify_desired_objects(rolename, mockdbcontext):
     roles = list(ROLES[:3])
     # We have to remove this role since we don't grant default privileges to ourselves
     roles.remove(rolename)
-    expected_defaults = set(itertools.product(roles, [SCHEMAS[0]], possible_privs))
+    expected_defaults = set(itertools.product(roles, [ObjectName(SCHEMAS[0])], possible_privs))
 
     actual_defaults = privconf.desired_defaults
     assert actual_defaults == expected_defaults
@@ -497,9 +497,9 @@ def test_identify_desired_objects_personal_schemas_object_kind_is_not_schema(moc
     # Check default privileges
     possible_privs = privs.PRIVILEGE_MAP[object_kind][access]
     expected_defaults = set([
-        (ROLES[2], ROLES[2], possible_privs[0]),
-        (ROLES[1], ROLES[2], possible_privs[0]),
-        (ROLES[3], ROLES[3], possible_privs[0])
+        (ROLES[2], ObjectName(ROLES[2]), possible_privs[0]),
+        (ROLES[1], ObjectName(ROLES[2]), possible_privs[0]),
+        (ROLES[3], ObjectName(ROLES[3]), possible_privs[0])
     ])
     actual_defaults = privconf.desired_defaults
     assert actual_defaults == expected_defaults

--- a/tests/test_privileges.py
+++ b/tests/test_privileges.py
@@ -328,7 +328,7 @@ def test_determine_desired_defaults(mockdbcontext):
     # Using sequence-write because it has 2 types of privileges (i.e. >1 but not a ton)
     object_kind = 'sequences'
     access = 'write'
-    schema_writers = {SCHEMAS[0]: set(ROLES[1:])}
+    schema_writers = {ObjectName(SCHEMAS[0]): set(ROLES[1:])}
     privconf = privs.PrivilegeAnalyzer(rolename=ROLES[0], access=access, object_kind=object_kind,
                                        desired_items=DUMMY, schema_writers=schema_writers,
                                        personal_schemas=DUMMY, dbcontext=mockdbcontext)
@@ -382,7 +382,7 @@ def test_identify_desired_objects(rolename, mockdbcontext):
         ObjectName(SCHEMAS[1], SEQUENCES[1])
     ]
 
-    schema_writers = {SCHEMAS[0]: set(ROLES[:3])}
+    schema_writers = {ObjectName(SCHEMAS[0]): set(ROLES[:3])}
 
     privconf = privs.PrivilegeAnalyzer(rolename, access=access, object_kind=object_kind,
                                        desired_items=desired_items, schema_writers=schema_writers,
@@ -486,8 +486,8 @@ def test_identify_desired_objects_personal_schemas_object_kind_is_not_schema(moc
         ObjectName('personal_schemas', '*')
     ]
     schema_writers = {
-        ROLES[2]: set([ROLES[2], ROLES[1]]),
-        ROLES[3]: set([ROLES[3]]),
+        ObjectName(ROLES[2]): set([ROLES[2], ROLES[1]]),
+        ObjectName(ROLES[3]): set([ROLES[3]]),
     }
     privconf = privs.PrivilegeAnalyzer(ROLES[0], access=access, object_kind=object_kind,
                                        desired_items=desired_items, schema_writers=schema_writers,
@@ -607,7 +607,7 @@ def test_analyze_defaults(mockdbcontext):
 
     desired_items = [ObjectName(SCHEMAS[0], '*')]
     schema_writers = {
-        SCHEMAS[0]: set([ROLES[1], ROLES[2]]),
+        ObjectName(SCHEMAS[0]): set([ROLES[1], ROLES[2]]),
     }
     privconf = privs.PrivilegeAnalyzer(rolename=ROLES[0], access='read', object_kind='tables',
                                        desired_items=desired_items, schema_writers=schema_writers,
@@ -749,11 +749,11 @@ def test_determine_schema_owners():
         'roleF': None,
     }
     expected = {
-        'roleA': 'roleA',
-        'roleB': 'roleB',
-        'schema1': 'roleA',
-        'schema2': 'roleA',
-        'schema3': 'roleC',
+        ObjectName('roleA'): 'roleA',
+        ObjectName('roleB'): 'roleB',
+        ObjectName('schema1'): 'roleA',
+        ObjectName('schema2'): 'roleA',
+        ObjectName('schema3'): 'roleC',
     }
     actual = privs.determine_schema_owners(spec)
     assert actual == expected
@@ -803,11 +803,11 @@ def test_determine_schema_writers():
         'roleH': {'is_superuser': 'true'},
     }
     expected = {
-        'roleA': set(['roleA', 'roleG', 'roleH', 'roleB']),
-        'roleB': set(['roleB', 'roleG', 'roleH']),
-        'schema1': set(['roleA', 'roleG', 'roleH']),
-        'schema2': set(['roleA', 'roleG', 'roleH']),
-        'schema3': set(['roleC', 'roleG', 'roleH', 'roleB']),
+        ObjectName('roleA'): set(['roleA', 'roleG', 'roleH', 'roleB']),
+        ObjectName('roleB'): set(['roleB', 'roleG', 'roleH']),
+        ObjectName('schema1'): set(['roleA', 'roleG', 'roleH']),
+        ObjectName('schema2'): set(['roleA', 'roleG', 'roleH']),
+        ObjectName('schema3'): set(['roleC', 'roleG', 'roleH', 'roleB']),
     }
     actual = privs.determine_schema_writers(spec)
     assert actual == expected

--- a/tests/test_privileges.py
+++ b/tests/test_privileges.py
@@ -539,7 +539,7 @@ def test_grant_default(mockdbcontext):
                                        personal_schemas=DUMMY, dbcontext=mockdbcontext)
 
     # Grant default privileges to role0 from role1 for this schema
-    privconf.grant_default(grantor=ROLES[1], schema=SCHEMAS[0], privilege='SELECT')
+    privconf.grant_default(grantor=ROLES[1], schema=ObjectName(SCHEMAS[0]), privilege='SELECT')
 
     expected = [privs.Q_GRANT_DEFAULT.format(ROLES[1], SCHEMAS[0], 'SELECT', 'TABLES', rolename)]
     assert privconf.sql_to_run == expected
@@ -553,7 +553,7 @@ def test_revoke_default(mockdbcontext):
                                        desired_items=DUMMY, schema_writers=DUMMY,
                                        personal_schemas=DUMMY, dbcontext=mockdbcontext)
 
-    privconf.revoke_default(grantor=ROLES[1], schema=SCHEMAS[0], privilege='SELECT')
+    privconf.revoke_default(grantor=ROLES[1], schema=ObjectName(SCHEMAS[0]), privilege='SELECT')
 
     expected = [privs.Q_REVOKE_DEFAULT.format(ROLES[1], SCHEMAS[0], 'SELECT', 'TABLES', rolename)]
     assert privconf.sql_to_run == expected

--- a/tests/test_spec_inspector.py
+++ b/tests/test_spec_inspector.py
@@ -4,7 +4,8 @@ import pytest
 import yaml
 
 from pgbedrock import spec_inspector
-from pgbedrock.context import ObjectAttributes, DBObject
+from pgbedrock.common import ObjectName
+from pgbedrock.context import ObjectAttributes
 
 
 @pytest.fixture
@@ -94,9 +95,9 @@ def test_ensure_no_object_owned_twice_schema_expansion_works(mockdbcontext):
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             'schema1': {
-                DBObject('schema1', 'table1'): {'owner': 'owner1', 'is_dependent': False},
-                DBObject('schema1', 'table2'): {'owner': 'owner2', 'is_dependent': False},
-                DBObject('schema1', 'table3'): {'owner': 'owner3', 'is_dependent': False},
+                ObjectName('schema1', 'table1'): {'owner': 'owner1', 'is_dependent': False},
+                ObjectName('schema1', 'table2'): {'owner': 'owner2', 'is_dependent': False},
+                ObjectName('schema1', 'table3'): {'owner': 'owner3', 'is_dependent': False},
             },
         },
     }
@@ -127,9 +128,9 @@ def test_ensure_no_object_owned_twice_personal_schemas_expanded(mockdbcontext):
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             'role0': {
-                DBObject('role0', 'table0'): {'owner': 'role0', 'is_dependent': False},
-                DBObject('role0', 'table1'): {'owner': 'role0', 'is_dependent': False},
-                DBObject('role0', 'table2'): {'owner': 'role0', 'is_dependent': False},
+                ObjectName('role0', 'table0'): {'owner': 'role0', 'is_dependent': False},
+                ObjectName('role0', 'table1'): {'owner': 'role0', 'is_dependent': False},
+                ObjectName('role0', 'table2'): {'owner': 'role0', 'is_dependent': False},
             },
         },
     }
@@ -155,14 +156,14 @@ def test_ensure_no_object_owned_twice_personal_schemas_expanded(mockdbcontext):
 
 def test_ensure_no_missing_objects_missing_in_db(mockdbcontext):
     mockdbcontext.get_all_raw_object_attributes = lambda: {
-        ObjectAttributes('tables', 'schema0', DBObject(schema='schema0', object_name='table1'), 'owner1', False),
-        ObjectAttributes('tables', 'schema0', DBObject(schema='schema0', object_name='table3'), 'owner3', False),
+        ObjectAttributes('tables', 'schema0', ObjectName(schema='schema0', object_name='table1'), 'owner1', False),
+        ObjectAttributes('tables', 'schema0', ObjectName(schema='schema0', object_name='table3'), 'owner3', False),
     }
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             'schema0': {
-                DBObject('schema0', 'table1'): {'owner': 'owner1', 'is_dependent': False},
-                DBObject('schema0', 'table3'): {'owner': 'owner3', 'is_dependent': False},
+                ObjectName('schema0', 'table1'): {'owner': 'owner1', 'is_dependent': False},
+                ObjectName('schema0', 'table3'): {'owner': 'owner3', 'is_dependent': False},
             },
         },
     }
@@ -185,21 +186,21 @@ def test_ensure_no_missing_objects_missing_in_db(mockdbcontext):
 
 def test_ensure_no_missing_objects_missing_in_spec(mockdbcontext):
     mockdbcontext.get_all_raw_object_attributes = lambda: {
-        ObjectAttributes('tables', 'schema0', DBObject(schema='schema0', object_name='table1'), 'owner1', False),
-        ObjectAttributes('tables', 'schema0', DBObject(schema='schema0', object_name='table2'), 'owner1', False),
-        ObjectAttributes('tables', 'schema0', DBObject(schema='schema0', object_name='table3'), 'owner3', False),
-        ObjectAttributes('tables', 'schema0', DBObject(schema='schema0', object_name='table4'), 'owner3', False),
+        ObjectAttributes('tables', 'schema0', ObjectName(schema='schema0', object_name='table1'), 'owner1', False),
+        ObjectAttributes('tables', 'schema0', ObjectName(schema='schema0', object_name='table2'), 'owner1', False),
+        ObjectAttributes('tables', 'schema0', ObjectName(schema='schema0', object_name='table3'), 'owner3', False),
+        ObjectAttributes('tables', 'schema0', ObjectName(schema='schema0', object_name='table4'), 'owner3', False),
         # This should be skipped as it is dependent
         ObjectAttributes('tables', 'schema0', 'schema0."table5"', 'owner3', True),
     }
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             'schema0': {
-                DBObject('schema0', 'table1'): {'owner': 'owner1', 'is_dependent': False},
-                DBObject('schema0', 'table2'): {'owner': 'owner1', 'is_dependent': False},
-                DBObject('schema0', 'table3'): {'owner': 'owner3', 'is_dependent': False},
-                DBObject('schema0', 'table4'): {'owner': 'owner3', 'is_dependent': False},
-                DBObject('schema0', 'table5'): {'owner': 'owner3', 'is_dependent': True},
+                ObjectName('schema0', 'table1'): {'owner': 'owner1', 'is_dependent': False},
+                ObjectName('schema0', 'table2'): {'owner': 'owner1', 'is_dependent': False},
+                ObjectName('schema0', 'table3'): {'owner': 'owner3', 'is_dependent': False},
+                ObjectName('schema0', 'table4'): {'owner': 'owner3', 'is_dependent': False},
+                ObjectName('schema0', 'table5'): {'owner': 'owner3', 'is_dependent': True},
             },
         },
     }
@@ -220,14 +221,14 @@ def test_ensure_no_missing_objects_missing_in_spec(mockdbcontext):
 
 def test_ensure_no_missing_objects_with_personal_schemas(mockdbcontext):
     mockdbcontext.get_all_raw_object_attributes = lambda: {
-        ObjectAttributes('tables', 'role0', DBObject(schema='role0', object_name='table1'), 'role0', False),
-        ObjectAttributes('tables', 'role0', DBObject(schema='role0', object_name='table2'), 'role0', False),
+        ObjectAttributes('tables', 'role0', ObjectName(schema='role0', object_name='table1'), 'role0', False),
+        ObjectAttributes('tables', 'role0', ObjectName(schema='role0', object_name='table2'), 'role0', False),
     }
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             'role0': {
-                DBObject('role0', 'table1'): {'owner': 'role0', 'is_dependent': False},
-                DBObject('role0', 'table2'): {'owner': 'role0', 'is_dependent': False},
+                ObjectName('role0', 'table1'): {'owner': 'role0', 'is_dependent': False},
+                ObjectName('role0', 'table2'): {'owner': 'role0', 'is_dependent': False},
             },
         },
     }
@@ -242,14 +243,14 @@ def test_ensure_no_missing_objects_with_personal_schemas(mockdbcontext):
 
 def test_ensure_no_missing_objects_schema_expansion_works(mockdbcontext):
     mockdbcontext.get_all_raw_object_attributes = lambda: {
-        ObjectAttributes('tables', 'schema0', DBObject(schema='schema0', object_name='table1'), 'owner1', False),
-        ObjectAttributes('tables', 'schema0', DBObject(schema='schema0', object_name='table2'), 'owner3', False),
+        ObjectAttributes('tables', 'schema0', ObjectName(schema='schema0', object_name='table1'), 'owner1', False),
+        ObjectAttributes('tables', 'schema0', ObjectName(schema='schema0', object_name='table2'), 'owner3', False),
     }
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             'schema0': {
-                DBObject('schema0', 'table1'): {'owner': 'owner1', 'is_dependent': False},
-                DBObject('schema0', 'table2'): {'owner': 'owner2', 'is_dependent': False},
+                ObjectName('schema0', 'table1'): {'owner': 'owner1', 'is_dependent': False},
+                ObjectName('schema0', 'table2'): {'owner': 'owner2', 'is_dependent': False},
             },
         },
     }
@@ -268,9 +269,9 @@ def test_ensure_no_dependent_object_is_owned(mockdbcontext):
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             'schema0': {
-                DBObject('schema0', 'table1'): {'owner': 'owner1', 'is_dependent': False},
-                DBObject('schema0', 'table2'): {'owner': 'owner2', 'is_dependent': True},
-                DBObject('schema0', 'table3'): {'owner': 'owner2', 'is_dependent': True},
+                ObjectName('schema0', 'table1'): {'owner': 'owner1', 'is_dependent': False},
+                ObjectName('schema0', 'table2'): {'owner': 'owner2', 'is_dependent': True},
+                ObjectName('schema0', 'table3'): {'owner': 'owner2', 'is_dependent': True},
             },
         },
     }
@@ -294,9 +295,9 @@ def test_ensure_no_dependent_object_is_owned_schema_expansion_skips_deps(mockdbc
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             'schema0': {
-                DBObject('schema0', 'table1'): {'owner': 'owner1', 'is_dependent': False},
-                DBObject('schema0', 'table2'): {'owner': 'owner2', 'is_dependent': True},
-                DBObject('schema0', 'table3'): {'owner': 'owner2', 'is_dependent': True},
+                ObjectName('schema0', 'table1'): {'owner': 'owner1', 'is_dependent': False},
+                ObjectName('schema0', 'table2'): {'owner': 'owner2', 'is_dependent': True},
+                ObjectName('schema0', 'table3'): {'owner': 'owner2', 'is_dependent': True},
             },
         },
     }
@@ -478,7 +479,7 @@ def test_ensure_no_undocumented_roles(mockdbcontext):
 
 def test_ensure_no_unowned_schemas(mockdbcontext):
     mockdbcontext.get_all_schemas_and_owners = lambda: {
-        DBObject('foo'): {}, DBObject('bar'): {}, DBObject('baz'): {}
+        ObjectName('foo'): {}, ObjectName('bar'): {}, ObjectName('baz'): {}
     }
     spec = {
         'qux': {

--- a/tests/test_spec_inspector.py
+++ b/tests/test_spec_inspector.py
@@ -156,8 +156,8 @@ def test_ensure_no_object_owned_twice_personal_schemas_expanded(mockdbcontext):
 
 def test_ensure_no_missing_objects_missing_in_db(mockdbcontext):
     mockdbcontext.get_all_raw_object_attributes = lambda: {
-        ObjectAttributes('tables', 'schema0', ObjectName(schema='schema0', object_name='table1'), 'owner1', False),
-        ObjectAttributes('tables', 'schema0', ObjectName(schema='schema0', object_name='table3'), 'owner3', False),
+        ObjectAttributes('tables', 'schema0', ObjectName('schema0', 'table1'), 'owner1', False),
+        ObjectAttributes('tables', 'schema0', ObjectName('schema0', 'table3'), 'owner3', False),
     }
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
@@ -186,10 +186,10 @@ def test_ensure_no_missing_objects_missing_in_db(mockdbcontext):
 
 def test_ensure_no_missing_objects_missing_in_spec(mockdbcontext):
     mockdbcontext.get_all_raw_object_attributes = lambda: {
-        ObjectAttributes('tables', 'schema0', ObjectName(schema='schema0', object_name='table1'), 'owner1', False),
-        ObjectAttributes('tables', 'schema0', ObjectName(schema='schema0', object_name='table2'), 'owner1', False),
-        ObjectAttributes('tables', 'schema0', ObjectName(schema='schema0', object_name='table3'), 'owner3', False),
-        ObjectAttributes('tables', 'schema0', ObjectName(schema='schema0', object_name='table4'), 'owner3', False),
+        ObjectAttributes('tables', 'schema0', ObjectName('schema0', 'table1'), 'owner1', False),
+        ObjectAttributes('tables', 'schema0', ObjectName('schema0', 'table2'), 'owner1', False),
+        ObjectAttributes('tables', 'schema0', ObjectName('schema0', 'table3'), 'owner3', False),
+        ObjectAttributes('tables', 'schema0', ObjectName('schema0', 'table4'), 'owner3', False),
         # This should be skipped as it is dependent
         ObjectAttributes('tables', 'schema0', 'schema0."table5"', 'owner3', True),
     }
@@ -221,8 +221,8 @@ def test_ensure_no_missing_objects_missing_in_spec(mockdbcontext):
 
 def test_ensure_no_missing_objects_with_personal_schemas(mockdbcontext):
     mockdbcontext.get_all_raw_object_attributes = lambda: {
-        ObjectAttributes('tables', 'role0', ObjectName(schema='role0', object_name='table1'), 'role0', False),
-        ObjectAttributes('tables', 'role0', ObjectName(schema='role0', object_name='table2'), 'role0', False),
+        ObjectAttributes('tables', 'role0', ObjectName('role0', 'table1'), 'role0', False),
+        ObjectAttributes('tables', 'role0', ObjectName('role0', 'table2'), 'role0', False),
     }
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
@@ -243,8 +243,8 @@ def test_ensure_no_missing_objects_with_personal_schemas(mockdbcontext):
 
 def test_ensure_no_missing_objects_schema_expansion_works(mockdbcontext):
     mockdbcontext.get_all_raw_object_attributes = lambda: {
-        ObjectAttributes('tables', 'schema0', ObjectName(schema='schema0', object_name='table1'), 'owner1', False),
-        ObjectAttributes('tables', 'schema0', ObjectName(schema='schema0', object_name='table2'), 'owner3', False),
+        ObjectAttributes('tables', 'schema0', ObjectName('schema0', 'table1'), 'owner1', False),
+        ObjectAttributes('tables', 'schema0', ObjectName('schema0', 'table2'), 'owner3', False),
     }
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {

--- a/tests/test_spec_inspector.py
+++ b/tests/test_spec_inspector.py
@@ -4,7 +4,7 @@ import pytest
 import yaml
 
 from pgbedrock import spec_inspector
-from pgbedrock.context import ObjectAttributes
+from pgbedrock.context import ObjectAttributes, DBObject
 
 
 @pytest.fixture
@@ -155,8 +155,8 @@ def test_ensure_no_object_owned_twice_personal_schemas_expanded(mockdbcontext):
 
 def test_ensure_no_missing_objects_missing_in_db(mockdbcontext):
     mockdbcontext.get_all_raw_object_attributes = lambda: {
-        ObjectAttributes('tables', 'schema0', 'schema0."table1"', 'owner1', False),
-        ObjectAttributes('tables', 'schema0', 'schema0."table3"', 'owner3', False),
+        ObjectAttributes('tables', 'schema0', DBObject(schema='schema0', object_name='table1'), 'owner1', False),
+        ObjectAttributes('tables', 'schema0', DBObject(schema='schema0', object_name='table3'), 'owner3', False),
     }
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
@@ -185,10 +185,10 @@ def test_ensure_no_missing_objects_missing_in_db(mockdbcontext):
 
 def test_ensure_no_missing_objects_missing_in_spec(mockdbcontext):
     mockdbcontext.get_all_raw_object_attributes = lambda: {
-        ObjectAttributes('tables', 'schema0', 'schema0."table1"', 'owner1', False),
-        ObjectAttributes('tables', 'schema0', 'schema0."table2"', 'owner1', False),
-        ObjectAttributes('tables', 'schema0', 'schema0."table3"', 'owner3', False),
-        ObjectAttributes('tables', 'schema0', 'schema0."table4"', 'owner3', False),
+        ObjectAttributes('tables', 'schema0', DBObject(schema='schema0', object_name='table1'), 'owner1', False),
+        ObjectAttributes('tables', 'schema0', DBObject(schema='schema0', object_name='table2'), 'owner1', False),
+        ObjectAttributes('tables', 'schema0', DBObject(schema='schema0', object_name='table3'), 'owner3', False),
+        ObjectAttributes('tables', 'schema0', DBObject(schema='schema0', object_name='table4'), 'owner3', False),
         # This should be skipped as it is dependent
         ObjectAttributes('tables', 'schema0', 'schema0."table5"', 'owner3', True),
     }
@@ -220,8 +220,8 @@ def test_ensure_no_missing_objects_missing_in_spec(mockdbcontext):
 
 def test_ensure_no_missing_objects_with_personal_schemas(mockdbcontext):
     mockdbcontext.get_all_raw_object_attributes = lambda: {
-        ObjectAttributes('tables', 'role0', 'role0."table1"', 'role0', False),
-        ObjectAttributes('tables', 'role0', 'role0."table2"', 'role0', False),
+        ObjectAttributes('tables', 'role0', DBObject(schema='role0', object_name='table1'), 'role0', False),
+        ObjectAttributes('tables', 'role0', DBObject(schema='role0', object_name='table2'), 'role0', False),
     }
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
@@ -242,8 +242,8 @@ def test_ensure_no_missing_objects_with_personal_schemas(mockdbcontext):
 
 def test_ensure_no_missing_objects_schema_expansion_works(mockdbcontext):
     mockdbcontext.get_all_raw_object_attributes = lambda: {
-        ObjectAttributes('tables', 'schema0', 'schema0."table1"', 'owner1', False),
-        ObjectAttributes('tables', 'schema0', 'schema0."table2"', 'owner3', False),
+        ObjectAttributes('tables', 'schema0', DBObject(schema='schema0', object_name='table1'), 'owner1', False),
+        ObjectAttributes('tables', 'schema0', DBObject(schema='schema0', object_name='table2'), 'owner3', False),
     }
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {

--- a/tests/test_spec_inspector.py
+++ b/tests/test_spec_inspector.py
@@ -28,7 +28,8 @@ def test_ensure_no_schema_owned_twice():
             schemas:
                 - finance_documents
     """
-    spec = yaml.load(spec_yaml)
+    unconverted_spec = yaml.load(spec_yaml)
+    spec = spec_inspector.convert_spec_to_objectnames(unconverted_spec)
     errors = spec_inspector.ensure_no_schema_owned_twice(spec)
     expected = spec_inspector.MULTIPLE_SCHEMA_OWNER_ERR_MSG.format('finance_documents',
                                                                    'jfauxnance, jfinance')
@@ -47,7 +48,8 @@ def test_ensure_no_schema_owned_twice_with_personal_schemas():
             schemas:
                 - jfinance
     """
-    spec = yaml.load(spec_yaml)
+    unconverted_spec = yaml.load(spec_yaml)
+    spec = spec_inspector.convert_spec_to_objectnames(unconverted_spec)
     errors = spec_inspector.ensure_no_schema_owned_twice(spec)
     expected = spec_inspector.MULTIPLE_SCHEMA_OWNER_ERR_MSG.format('jfinance',
                                                                    'jfauxnance, jfinance')
@@ -84,7 +86,8 @@ def test_ensure_no_object_owned_twice(mockdbcontext):
                 - schema1.table1
                 - schema1."table2"
     """
-    spec = yaml.load(spec_yaml)
+    unconverted_spec = yaml.load(spec_yaml)
+    spec = spec_inspector.convert_spec_to_objectnames(unconverted_spec)
     errors = spec_inspector.ensure_no_object_owned_twice(spec, mockdbcontext, 'tables')
     expected = spec_inspector.MULTIPLE_OBJKIND_OWNER_ERR_MSG.format('Table', 'schema1."table1"',
                                                                     'role0, role1')
@@ -115,7 +118,8 @@ def test_ensure_no_object_owned_twice_schema_expansion_works(mockdbcontext):
                 - schema1."table1"
                 - schema1.table3
     """
-    spec = yaml.load(spec_yaml)
+    unconverted_spec = yaml.load(spec_yaml)
+    spec = spec_inspector.convert_spec_to_objectnames(unconverted_spec)
     errors = spec_inspector.ensure_no_object_owned_twice(spec, mockdbcontext, 'tables')
     expected = set([
         spec_inspector.MULTIPLE_OBJKIND_OWNER_ERR_MSG.format('Table', 'schema1."table1"', 'role0, role1'),
@@ -145,7 +149,8 @@ def test_ensure_no_object_owned_twice_personal_schemas_expanded(mockdbcontext):
                 - role0."table0"
                 - role0.table1
     """
-    spec = yaml.load(spec_yaml)
+    unconverted_spec = yaml.load(spec_yaml)
+    spec = spec_inspector.convert_spec_to_objectnames(unconverted_spec)
     errors = spec_inspector.ensure_no_object_owned_twice(spec, mockdbcontext, 'tables')
     expected = set([
         spec_inspector.MULTIPLE_OBJKIND_OWNER_ERR_MSG.format('Table', 'role0."table0"', 'role0, role1'),
@@ -177,7 +182,8 @@ def test_ensure_no_missing_objects_missing_in_db(mockdbcontext):
                 - schema0.table3
                 - schema0.table4
     """
-    spec = yaml.load(spec_yaml)
+    unconverted_spec = yaml.load(spec_yaml)
+    spec = spec_inspector.convert_spec_to_objectnames(unconverted_spec)
     errors = spec_inspector.ensure_no_missing_objects(spec, mockdbcontext, 'tables')
     expected = spec_inspector.UNKNOWN_OBJECTS_MSG.format(objkind='tables',
                                                          unknown_objects='schema0."table2", schema0."table4"')
@@ -212,7 +218,8 @@ def test_ensure_no_missing_objects_missing_in_spec(mockdbcontext):
                 - schema0."table1"
                 - schema0.table3
     """
-    spec = yaml.load(spec_yaml)
+    unconverted_spec = yaml.load(spec_yaml)
+    spec = spec_inspector.convert_spec_to_objectnames(unconverted_spec)
     errors = spec_inspector.ensure_no_missing_objects(spec, mockdbcontext, 'tables')
     expected = spec_inspector.UNOWNED_OBJECTS_MSG.format(objkind='tables',
                                                          unowned_objects='schema0."table2", schema0."table4"')
@@ -236,7 +243,8 @@ def test_ensure_no_missing_objects_with_personal_schemas(mockdbcontext):
     role0:
         has_personal_schema: true
     """
-    spec = yaml.load(spec_yaml)
+    unconverted_spec = yaml.load(spec_yaml)
+    spec = spec_inspector.convert_spec_to_objectnames(unconverted_spec)
     errors = spec_inspector.ensure_no_missing_objects(spec, mockdbcontext, 'tables')
     assert errors == []
 
@@ -260,7 +268,8 @@ def test_ensure_no_missing_objects_schema_expansion_works(mockdbcontext):
             tables:
                 - schema0.*
     """
-    spec = yaml.load(spec_yaml)
+    unconverted_spec = yaml.load(spec_yaml)
+    spec = spec_inspector.convert_spec_to_objectnames(unconverted_spec)
     errors = spec_inspector.ensure_no_missing_objects(spec, mockdbcontext, 'tables')
     assert errors == []
 
@@ -284,7 +293,8 @@ def test_ensure_no_dependent_object_is_owned(mockdbcontext):
                 - schema0.table2
                 - schema0.table3
     """
-    spec = yaml.load(spec_yaml)
+    unconverted_spec = yaml.load(spec_yaml)
+    spec = spec_inspector.convert_spec_to_objectnames(unconverted_spec)
     errors = spec_inspector.ensure_no_dependent_object_is_owned(spec, mockdbcontext, 'tables')
     expected = spec_inspector.DEPENDENT_OBJECTS_MSG.format(objkind='tables',
                                                            dep_objs='schema0."table2", schema0."table3"')
@@ -307,7 +317,8 @@ def test_ensure_no_dependent_object_is_owned_schema_expansion_skips_deps(mockdbc
             tables:
                 - schema0.*
     """
-    spec = yaml.load(spec_yaml)
+    unconverted_spec = yaml.load(spec_yaml)
+    spec = spec_inspector.convert_spec_to_objectnames(unconverted_spec)
     errors = spec_inspector.ensure_no_dependent_object_is_owned(spec, mockdbcontext, 'tables')
     assert errors == []
 
@@ -334,7 +345,8 @@ def test_verify_spec_fails_object_referenced_read_write():
 
     privilege_types = ('schemas', 'sequences', 'tables')
     for t in privilege_types:
-        spec = yaml.load(spec_yaml.format(t))
+        unconverted_spec = yaml.load(spec_yaml.format(t))
+        spec = spec_inspector.convert_spec_to_objectnames(unconverted_spec)
         errors = spec_inspector.ensure_no_redundant_privileges(spec)
         err_string = "margerie: {'%s': ['big_bad']}" % t
         expected = spec_inspector.OBJECT_REF_READ_WRITE_ERR.format(err_string)
@@ -363,7 +375,7 @@ def test_verify_spec_fails_role_defined_multiple_times(tmpdir):
     assert [expected] == errors
 
 
-def test_verify_spec_fails():
+def test_ensure_valid_schema_fails():
     """ We could check more functionality, but at that point we'd just be testing cerberus. This
     test is just to verify that a failure will happen and will be presented as we'd expect """
     spec_yaml = """
@@ -377,7 +389,7 @@ def test_verify_spec_fails():
     assert expected == errors[0]
 
 
-def test_verify_spec_succeeds():
+def test_ensure_valid_schema_succeeds():
     spec_yaml = """
         fred:
             attributes:
@@ -484,7 +496,7 @@ def test_ensure_no_unowned_schemas(mockdbcontext):
     spec = {
         'qux': {
             'owns': {
-                'schemas': ['baz'],
+                'schemas': [ObjectName('baz')],
             },
         },
     }

--- a/tests/test_spec_inspector.py
+++ b/tests/test_spec_inspector.py
@@ -510,17 +510,19 @@ def test_get_spec_schemas():
         'role0': {
              'has_personal_schema': True,
              'owns': {
-                 'schemas': ['schemas0']
+                 'schemas': [ObjectName('schemas0')]
              },
         },
         'role1': {
              'owns': {
-                 'schemas': ['schemas1']
+                 'schemas': [ObjectName('schemas1')]
              },
         }
     }
 
-    assert spec_inspector.get_spec_schemas(spec) == set(['role0', 'schemas0', 'schemas1'])
+    expected = set([ObjectName('role0'), ObjectName('schemas0'), ObjectName('schemas1')])
+    actual = spec_inspector.get_spec_schemas(spec)
+    assert actual == expected
 
 
 def test_convert_spec_to_objectnames_owns_subdict():

--- a/tests/test_spec_inspector.py
+++ b/tests/test_spec_inspector.py
@@ -94,9 +94,9 @@ def test_ensure_no_object_owned_twice_schema_expansion_works(mockdbcontext):
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             'schema1': {
-                'schema1."table1"': {'owner': 'owner1', 'is_dependent': False},
-                'schema1."table2"': {'owner': 'owner2', 'is_dependent': False},
-                'schema1."table3"': {'owner': 'owner3', 'is_dependent': False},
+                DBObject('schema1', 'table1'): {'owner': 'owner1', 'is_dependent': False},
+                DBObject('schema1', 'table2'): {'owner': 'owner2', 'is_dependent': False},
+                DBObject('schema1', 'table3'): {'owner': 'owner3', 'is_dependent': False},
             },
         },
     }
@@ -127,9 +127,9 @@ def test_ensure_no_object_owned_twice_personal_schemas_expanded(mockdbcontext):
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             'role0': {
-                'role0."table0"': {'owner': 'role0', 'is_dependent': False},
-                'role0."table1"': {'owner': 'role0', 'is_dependent': False},
-                'role0."table2"': {'owner': 'role0', 'is_dependent': False},
+                DBObject('role0', 'table0'): {'owner': 'role0', 'is_dependent': False},
+                DBObject('role0', 'table1'): {'owner': 'role0', 'is_dependent': False},
+                DBObject('role0', 'table2'): {'owner': 'role0', 'is_dependent': False},
             },
         },
     }
@@ -161,8 +161,8 @@ def test_ensure_no_missing_objects_missing_in_db(mockdbcontext):
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             'schema0': {
-                'schema0."table1"': {'owner': 'owner1', 'is_dependent': False},
-                'schema0."table3"': {'owner': 'owner3', 'is_dependent': False},
+                DBObject('schema0', 'table1'): {'owner': 'owner1', 'is_dependent': False},
+                DBObject('schema0', 'table3'): {'owner': 'owner3', 'is_dependent': False},
             },
         },
     }
@@ -195,11 +195,11 @@ def test_ensure_no_missing_objects_missing_in_spec(mockdbcontext):
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             'schema0': {
-                'schema0."table1"': {'owner': 'owner1', 'is_dependent': False},
-                'schema0."table2"': {'owner': 'owner1', 'is_dependent': False},
-                'schema0."table3"': {'owner': 'owner3', 'is_dependent': False},
-                'schema0."table4"': {'owner': 'owner3', 'is_dependent': False},
-                'schema0."table5"': {'owner': 'owner3', 'is_dependent': True},
+                DBObject('schema0', 'table1'): {'owner': 'owner1', 'is_dependent': False},
+                DBObject('schema0', 'table2'): {'owner': 'owner1', 'is_dependent': False},
+                DBObject('schema0', 'table3'): {'owner': 'owner3', 'is_dependent': False},
+                DBObject('schema0', 'table4'): {'owner': 'owner3', 'is_dependent': False},
+                DBObject('schema0', 'table5'): {'owner': 'owner3', 'is_dependent': True},
             },
         },
     }
@@ -226,8 +226,8 @@ def test_ensure_no_missing_objects_with_personal_schemas(mockdbcontext):
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             'role0': {
-                'role0."table1"': {'owner': 'role0', 'is_dependent': False},
-                'role0."table2"': {'owner': 'role0', 'is_dependent': False},
+                DBObject('role0', 'table1'): {'owner': 'role0', 'is_dependent': False},
+                DBObject('role0', 'table2'): {'owner': 'role0', 'is_dependent': False},
             },
         },
     }
@@ -248,8 +248,8 @@ def test_ensure_no_missing_objects_schema_expansion_works(mockdbcontext):
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             'schema0': {
-                'schema0."table1"': {'owner': 'owner1', 'is_dependent': False},
-                'schema0."table2"': {'owner': 'owner2', 'is_dependent': False},
+                DBObject('schema0', 'table1'): {'owner': 'owner1', 'is_dependent': False},
+                DBObject('schema0', 'table2'): {'owner': 'owner2', 'is_dependent': False},
             },
         },
     }
@@ -268,9 +268,9 @@ def test_ensure_no_dependent_object_is_owned(mockdbcontext):
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             'schema0': {
-                'schema0."table1"': {'owner': 'owner1', 'is_dependent': False},
-                'schema0."table2"': {'owner': 'owner2', 'is_dependent': True},
-                'schema0."table3"': {'owner': 'owner2', 'is_dependent': True},
+                DBObject('schema0', 'table1'): {'owner': 'owner1', 'is_dependent': False},
+                DBObject('schema0', 'table2'): {'owner': 'owner2', 'is_dependent': True},
+                DBObject('schema0', 'table3'): {'owner': 'owner2', 'is_dependent': True},
             },
         },
     }
@@ -294,9 +294,9 @@ def test_ensure_no_dependent_object_is_owned_schema_expansion_skips_deps(mockdbc
     mockdbcontext.get_all_object_attributes = lambda: {
         'tables': {
             'schema0': {
-                'schema0.table1': {'owner': 'owner1', 'is_dependent': False},
-                'schema0.table2': {'owner': 'owner2', 'is_dependent': True},
-                'schema0.table3': {'owner': 'owner2', 'is_dependent': True},
+                DBObject('schema0', 'table1'): {'owner': 'owner1', 'is_dependent': False},
+                DBObject('schema0', 'table2'): {'owner': 'owner2', 'is_dependent': True},
+                DBObject('schema0', 'table3'): {'owner': 'owner2', 'is_dependent': True},
             },
         },
     }

--- a/tests/test_spec_inspector.py
+++ b/tests/test_spec_inspector.py
@@ -477,7 +477,9 @@ def test_ensure_no_undocumented_roles(mockdbcontext):
 
 
 def test_ensure_no_unowned_schemas(mockdbcontext):
-    mockdbcontext.get_all_schemas_and_owners = lambda: {'foo': {}, 'bar': {}, 'baz': {}}
+    mockdbcontext.get_all_schemas_and_owners = lambda: {
+        DBObject('foo'): {}, DBObject('bar'): {}, DBObject('baz'): {}
+    }
     spec = {
         'qux': {
             'owns': {


### PR DESCRIPTION
This is the worst PR I've ever made. To try to justify this ugly mess so I don't feel so lousy: the choice was between one huge, incomprehensible PR (this) and 48 tiny PRs that were comprehensible and would leave the repo in a good place. My reasons for going this route were:

- This PR represents the "atomic" change we're looking for: moving from not using ObjectName instances to using them everywhere. Each of the 48 intermediate commits would all leave the repo in a weird half-and-half state, though admittedly the tests pass at each commit.
- 48 PRs would have resulted in a LOT of back-and-forth and a ton of time. Given that I leave for several months of vacation in a few days, I was pushing for speed over proper process.
- Everything in this PR is changing plumbing. Basically, where we were using strings before use an instance of a class. While on the one hand it may have been a way to get people to know the plumbing of pgbedrock, it's also a way to burn a lot of goodwill and kill people's interest in reviewing PRs. Rather than having people review plumbing, I'd prefer to talk about features and non-trivial changes.
- Although it's possible that I may have screwed something up with my changes to the plumbing, we have 96% test coverage and I've tested this against Squarespace's relatively complex use case, so I feel pretty good about the fact that the changes I made didn't break anything. And if they do (which would suck), we have prior docker images and pypi versions available.

With the above given as an attempt to exonerate myself from guilt (which I still feel), I think it'd be useful to discuss this PR in person and see if there's anything else that would be useful to do for due diligence. Actually reviewing the medley of changes seems like a bad use of time.