### PR TITLE
Move pinned dependencies to requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ VOLUME /opt
 WORKDIR /opt
 
 COPY setup.py /opt/
+COPY requirements.txt /opt/
 COPY pgbedrock /opt/pgbedrock
+RUN pip install -r requirements.txt
 RUN pip install .
 
 ENTRYPOINT ["pgbedrock"]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.rst LICENSE requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+Cerberus==1.1
+click==6.7
+Jinja2==2.9.6
+MarkupSafe==1.0
+psycopg2==2.7.3
+PyYAML==3.12

--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,11 @@ def get_version():
 
 
 required = [
-    'click==6.7',
-    'psycopg2==2.7.3',
-    'PyYAML==3.12',
-    'Jinja2==2.9.6',
-    'cerberus==1.1',
+    'Cerberus',
+    'click',
+    'Jinja2',
+    'psycopg2',
+    'PyYAML',
 ]
 
 setup(


### PR DESCRIPTION
Pinned dependencies in `setup.py` make it difficult to use `pgbedrock` in environments that are shared with other packages. If a user upgrades a dependency and tries to execute `pgbedrock` they can get a `pkg_resources.DistributionNotFound` error.

This pull request relaxes the dependency constraints in `setup.py` and adds `requirements.txt`. The relaxed constraints in `setup.py` enable the user to execute `pgbedrock` in more environments, while the pinning in `requirements.txt` provides users and developers with a "known good" environment.

`pgbedrock` seems to work correctly with the latest versions of all dependencies. I do not know whether there are any known minimum version requirements for any of the dependencies, but if there are please add them to `setup.py`.