### PR TITLE
Execute SQL only with option --live

### DIFF
--- a/pgbedrock/core_configure.py
+++ b/pgbedrock/core_configure.py
@@ -143,7 +143,7 @@ def configure(spec_path, host, port, user, password, dbname, prompt, attributes,
     if ownerships:
         sql_to_run.append(create_divider('ownerships'))
         module_sql = analyze_ownerships(spec, cursor, live, verbose)
-        run_module_sql(module_sql, cursor, verbose)
+        run_module_sql(module_sql, cursor, live, verbose)
         sql_to_run.extend(module_sql)
 
     if privileges:

--- a/pgbedrock/core_configure.py
+++ b/pgbedrock/core_configure.py
@@ -142,7 +142,7 @@ def configure(spec_path, host, port, user, password, dbname, prompt, attributes,
 
     if ownerships:
         sql_to_run.append(create_divider('ownerships'))
-        module_sql = analyze_ownerships(spec, cursor, live, verbose)
+        module_sql = analyze_ownerships(spec, cursor, verbose)
         run_module_sql(module_sql, cursor, live, verbose)
         sql_to_run.extend(module_sql)
 


### PR DESCRIPTION
The reason behind this change:
I have several databases with pretty big numbers of users, schemas and tables. 
At first, I've run pgbedrock with option 'generate' to generate configuration files. Then I've run pgbedrock with 'configure --check' parameter with output redirected to file. Practically all Postgres session hanged up. When I killed such sessions (using pg_terminate_backend), I found file generated by pgbedrock with pretty big number of SQL commands (up to 300.000 lines). 
It were commands like
grant REFERENCES/TRIGGER/TRUNCATE ...
and
alter DEFAULTE PRIVILEGE ... TO <superuser_name>
I supposed that the problem was in 'rollback' all these command.
To fix this, I tried to skip execution of these commands if parameter 'live' set to 'False'.
My tests showed that this really fix the problem, and all output files were generated as expected.
This change also make pgbedrock run faster with '--check' option because we do not need to execute generated SQL statements and then roll them back.
I hope this change will make pgbedrock a little bit better.