### PR TITLE
Add restrict list option to pgbedrock configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,8 @@ As an example, the definition for the ``jdoe`` role in the spec might look like 
                     - marketing.impressions
                 write:
                     - reports.*
+                except:
+                    - reports.Q2_fixed_assets
             sequences:
                 write:
                     - reports.*
@@ -84,7 +86,7 @@ When pgbedrock is run, it would make sure that:
       ``marketing.ad_spend`` and ``marketing.impressions`` tables
     * ``jdoe`` has default privileges to read from all future tables created in the ``finance`` schema
     * ``jdoe`` has write-level access (``SELECT``, ``INSERT``, ``UPDATE``, ``DELETE``, ``TRUNCATE``,
-      ``REFERENCES``, and ``TRIGGER``) to all tables in the ``reports`` schema
+      ``REFERENCES``, and ``TRIGGER``) to all tables in the ``reports`` schema EXCEPT for the Q2_fixed_assets table
     * ``jdoe`` has default privileges to write to all future tables created in the ``reports`` schema
     * ``jdoe`` has write-level access (``SELECT``, ``USAGE``, ``UPDATE``) to all sequences in the
       ``reports`` schema

--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ When pgbedrock is run, it would make sure that:
       ``marketing.ad_spend`` and ``marketing.impressions`` tables
     * ``jdoe`` has default privileges to read from all future tables created in the ``finance`` schema
     * ``jdoe`` has write-level access (``SELECT``, ``INSERT``, ``UPDATE``, ``DELETE``, ``TRUNCATE``,
-      ``REFERENCES``, and ``TRIGGER``) to all tables in the ``reports`` schema EXCEPT for the Q2_fixed_assets table
+      ``REFERENCES``, and ``TRIGGER``) to all tables in the ``reports`` schema except for the ``Q2_fixed_assets`` table
     * ``jdoe`` has default privileges to write to all future tables created in the ``reports`` schema
     * ``jdoe`` has write-level access (``SELECT``, ``USAGE``, ``UPDATE``) to all sequences in the
       ``reports`` schema

--- a/pgbedrock/privileges.py
+++ b/pgbedrock/privileges.py
@@ -54,6 +54,7 @@ def analyze_privileges(spec, cursor, verbose):
 
             for object_kind in PRIVILEGE_MAP.keys():
                 desired_items_this_obj = all_desired_privs.get(object_kind, {})
+                restricted_items_this_obj = all_desired_privs.get('restrict', {})
 
                 for access in ('read', 'write'):
                     desired_items = desired_items_this_obj.get(access, [])
@@ -67,7 +68,8 @@ def analyze_privileges(spec, cursor, verbose):
                                                  desired_items=desired_items,
                                                  dbcontext=dbcontext,
                                                  schema_writers=schema_writers,
-                                                 personal_schemas=personal_schemas)
+                                                 personal_schemas=personal_schemas,
+                                                 restricted_items_this_obj=restricted_items_this_obj)
                     role_sql_to_run = privconf.analyze()
                     all_sql_to_run += role_sql_to_run
 
@@ -181,7 +183,7 @@ class PrivilegeAnalyzer(object):
     """
 
     def __init__(self, rolename, access, object_kind, desired_items, schema_writers,
-                 personal_schemas, dbcontext):
+                 personal_schemas, dbcontext, restricted_items):
         log_msg = 'Initializing PrivilegeAnalyzer for rolename "{}", access "{}", and object "{}"'
         logger.debug(log_msg.format(rolename, access, object_kind))
         self.sql_to_run = []
@@ -190,6 +192,7 @@ class PrivilegeAnalyzer(object):
         self.access = access
         self.object_kind = object_kind
         self.desired_items = desired_items
+        self.restricted_items = restricted_items
         self.schema_writers = schema_writers
         self.personal_schemas = personal_schemas
         self.default_acl_possible = self.object_kind in OBJECTS_WITH_DEFAULTS
@@ -319,6 +322,9 @@ class PrivilegeAnalyzer(object):
             # existing objects not owned by this role and add them to self.desired_nondefaults
             schema_objects = self.get_schema_objects(schema.qualified_name)
             desired_nondefault_objs.update(schema_objects)
+
+        #Remove restricted elements
+        desired_nondefault_objs.difference_update(self.restricted_items)
 
         # Cross our desired objects with the desired privileges
         priv_types = PRIVILEGE_MAP[self.object_kind][self.access]

--- a/pgbedrock/privileges.py
+++ b/pgbedrock/privileges.py
@@ -69,7 +69,7 @@ def analyze_privileges(spec, cursor, verbose):
                                                  dbcontext=dbcontext,
                                                  schema_writers=schema_writers,
                                                  personal_schemas=personal_schemas,
-                                                 restricted_items_this_obj=restricted_items_this_obj)
+                                                 restricted_items=restricted_items_this_obj)
                     role_sql_to_run = privconf.analyze()
                     all_sql_to_run += role_sql_to_run
 

--- a/pgbedrock/spec_inspector.py
+++ b/pgbedrock/spec_inspector.py
@@ -35,7 +35,7 @@ UNOWNED_SCHEMAS_MSG = ('Spec error: Schemas found in database with no owner in s
                        'Please add these schemas to the spec file or manually remove '
                        'them from the Postgres cluster')
 RESTRICTED_SCHEMAS_MSG = ('Spec error: Schema found with restrict privilege for role: {}\n'
-                       'Restrict may only be used for tables and sequences ')
+                          'Restrict may only be used for tables and sequences ')
 VALIDATION_ERR_MSG = 'Spec error: Role "{}", field "{}": {}'
 
 SPEC_SCHEMA_YAML = """

--- a/pgbedrock/spec_inspector.py
+++ b/pgbedrock/spec_inspector.py
@@ -77,6 +77,7 @@ SPEC_SCHEMA_YAML = """
             allowed:
                 - read
                 - write
+                - restrict
             valueschema:
                 type: list
                 schema:
@@ -401,7 +402,6 @@ def get_spec_schemas(spec):
             spec_schemas.append(common.ObjectName(rolename))
 
     return set(spec_schemas)
-
 
 def load_spec(spec_path, cursor, verbose, attributes, memberships, ownerships, privileges):
     """ Validate a spec passes various checks and, if so, return the loaded spec. """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Cerberus==1.1
 click==6.7
-Jinja2==2.9.6
+Jinja2==2.10.1
 MarkupSafe==1.0
 psycopg2==2.7.3
-PyYAML==3.12
+PyYAML==5.1

--- a/tests/test_privileges.py
+++ b/tests/test_privileges.py
@@ -110,6 +110,13 @@ def test_analyze_privileges(cursor):
                     - schema0
                     - schema1
                     - schema2
+        Role4:
+            privileges:
+                tables:
+                    read:
+                        - schema0.*
+                    restrict:
+                        - schema0.table2 (Role4 can read all tables except for table 2 in schema 0)
     """
     unconverted_desired_spec = yaml.load("""
         {role0}:

--- a/tests/test_spec_inspector.py
+++ b/tests/test_spec_inspector.py
@@ -582,7 +582,7 @@ def test_convert_spec_to_objectnames_privileges_subdict():
                         - myschema2.mytable1
                     write:
                         - myschema3.mytable1
-                    restrict:
+                    except:
                         - myschema1.mytable1
         """
 
@@ -606,7 +606,7 @@ def test_convert_spec_to_objectnames_privileges_subdict():
                     'write': [
                         ObjectName('myschema3', 'mytable1'),
                     ],
-                    'restrict': [
+                    'except': [
                         ObjectName('myschema1', 'mytable1'),
                     ],
                 }

--- a/tests/test_spec_inspector.py
+++ b/tests/test_spec_inspector.py
@@ -582,6 +582,8 @@ def test_convert_spec_to_objectnames_privileges_subdict():
                         - myschema2.mytable1
                     write:
                         - myschema3.mytable1
+                    restrict:
+                        - myschema1.mytable1
         """
 
     expected_spec = {
@@ -603,6 +605,9 @@ def test_convert_spec_to_objectnames_privileges_subdict():
                     ],
                     'write': [
                         ObjectName('myschema3', 'mytable1'),
+                    ],
+                    'restrict': [
+                        ObjectName('myschema1', 'mytable1'),
                     ],
                 }
             }


### PR DESCRIPTION
The purpose of this pull request is to allow users to restrict tables and sequences when they add privileges for the entire schema (using `schema_name.*`).  This will allow the user to blacklist tables that they do want to include in the standard privilege list instead of just the standard 

Users can add these restricted tables by doing the following in the configuration yaml file:
```
 user:
            privileges:
                tables:
                    read:
                        - schema0.*
                    restrict:
                        - schema0.table2 // user can read all tables except for table 2 in schema 0
```