### PR TITLE
Add tests against latest stable releases of  Postgres 11, 12, & 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ jobs:
           script: sudo make test
 
         - stage: # Intentionally left blank to parallelize
+          env: SUPPORTED_PG_VERSIONS=11.11
+          script: sudo make test
+
+        - stage: # Intentionally left blank to parallelize
           install: pip install -e . -r requirements-docs.txt
           script: make docs
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,14 @@ jobs:
           script: sudo make test
 
         - stage: # Intentionally left blank to parallelize
+          env: SUPPORTED_PG_VERSIONS=12.6
+          script: sudo make test
+
+        - stage: # Intentionally left blank to parallelize
+          env: SUPPORTED_PG_VERSIONS=13.2
+          script: sudo make test
+
+        - stage: # Intentionally left blank to parallelize
           install: pip install -e . -r requirements-docs.txt
           script: make docs
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: attach build build_tester clean coverage create_network docs psql release_pypi release_pypitest release_quay remove_network start_postgres stop_postgres test test_one_pg_version test27 test36 view_docs wait_for_postgres
 
-SUPPORTED_PG_VERSIONS ?= 9.5.13 9.6.4 10.4 11.11
+SUPPORTED_PG_VERSIONS ?= 9.5.13 9.6.4 10.4 11.11 12.6 13.2
 # The default Postgres that will be used in individual targets
 POSTGRES_VERSION ?= 10.4
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: attach build build_tester clean coverage create_network docs psql release_pypi release_pypitest release_quay remove_network start_postgres stop_postgres test test_one_pg_version test27 test36 view_docs wait_for_postgres
 
-SUPPORTED_PG_VERSIONS ?= 9.5.13 9.6.4 10.4
+SUPPORTED_PG_VERSIONS ?= 9.5.13 9.6.4 10.4 11.11
 # The default Postgres that will be used in individual targets
 POSTGRES_VERSION ?= 10.4
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Cerberus==1.1
 click==6.7
 Jinja2==2.10.1
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 psycopg2==2.7.3
 PyYAML==5.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,7 +67,9 @@ def drop_users_and_objects(cursor):
         WHERE rolname NOT IN (
             'test_user', 'postgres', 'pg_signal_backend',
             -- Roles introduced in Postgres 10:
-            'pg_monitor', 'pg_read_all_settings', 'pg_read_all_stats', 'pg_stat_scan_tables'
+            'pg_monitor', 'pg_read_all_settings', 'pg_read_all_stats', 'pg_stat_scan_tables',
+            -- Roles introduced in Postgres 11:
+            'pg_execute_server_program', 'pg_read_server_files', 'pg_write_server_files'
         );
         """)
     users = [u[0] for u in cursor.fetchall()]

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -324,12 +324,25 @@ def test_get_all_personal_schemas(cursor):
 def test_get_all_role_attributes(cursor):
     dbcontext = context.DatabaseContext(cursor, verbose=True)
 
-    expected = set(['test_user', 'postgres', ROLES[0], ROLES[1]])
-    pg_version = dbcontext.get_version_info().postgres_version
+    expected = set(['test_user', ROLES[0], ROLES[1]])
+
+    pg_version = int(dbcontext.get_version_info().postgres_version.split('.')[0])
+
+    if pg_version <= 10:
+        expected.update(set([
+            'postgres']
+        ))
+
     # Postgres 10 introduces several new roles that we have to account for
-    if pg_version.startswith('10.'):
+    if pg_version >= 10:
         expected.update(set([
             'pg_read_all_settings', 'pg_stat_scan_tables', 'pg_read_all_stats', 'pg_monitor']
+        ))
+
+    # Postgres 11 introduces several new roles that we have to account for
+    if pg_version >= 11:
+        expected.update(set([
+            'pg_read_server_files', 'pg_write_server_files', 'pg_execute_server_program']
         ))
 
     actual = dbcontext.get_all_role_attributes()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -425,9 +425,10 @@ def test_get_all_memberships(cursor):
     dbcontext = context.DatabaseContext(cursor, verbose=True)
 
     expected = set([('role1', 'role0'), ('role2', 'role1')])
-    pg_version = dbcontext.get_version_info().postgres_version
+    pg_version = int(dbcontext.get_version_info().postgres_version.split('.')[0])
+
     # Postgres 10 introduces several new roles and memberships that we have to account for
-    if pg_version.startswith('10.'):
+    if pg_version >= 10:
         expected.update(set([
             ('pg_monitor', 'pg_stat_scan_tables'),
             ('pg_monitor', 'pg_read_all_stats'),

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -14,6 +14,8 @@ ROLES = tuple('role{}'.format(i) for i in range(4))
 TABLES = tuple('table{}'.format(i) for i in range(6))
 SEQUENCES = tuple('seq{}'.format(i) for i in range(6))
 DUMMY = 'foo'
+TEST_USER='test_user'
+POSTGRES_USER='postgres'
 
 
 @run_setup_sql(
@@ -385,15 +387,18 @@ def test_is_superuser(all_role_attributes, expected):
     ])
 def test_get_all_schemas_and_owners(cursor):
     dbcontext = context.DatabaseContext(cursor, verbose=True)
+    pg_version = int(dbcontext.get_version_info().postgres_version.split('.')[0])
+
+    expected_owner = TEST_USER if pg_version >= 11 else POSTGRES_USER
     expected = {
         common.ObjectName(SCHEMAS[0]): ROLES[0],
         common.ObjectName(SCHEMAS[1]): ROLES[0],
         common.ObjectName(SCHEMAS[2]): ROLES[1],
         common.ObjectName(ROLES[1]): ROLES[1],
         # These already existed
-        common.ObjectName('public'): 'postgres',
-        common.ObjectName('information_schema'): 'postgres',
-        common.ObjectName('pg_catalog'): 'postgres',
+        common.ObjectName('public'): expected_owner,
+        common.ObjectName('information_schema'): expected_owner,
+        common.ObjectName('pg_catalog'): expected_owner,
     }
 
     actual = dbcontext.get_all_schemas_and_owners()

--- a/tests/test_core_configure.py
+++ b/tests/test_core_configure.py
@@ -78,7 +78,7 @@ def test_configure_live_mode_works(capsys, cursor, spec_with_new_user, db_config
     assert cursor.rowcount == expected
 
     if live_mode:
-        cursor.execute(Q_HAS_ROLE.format(NEW_USER, 'postgres'))
+        cursor.execute(Q_HAS_ROLE.format(NEW_USER, 'test_user'))
         assert cursor.rowcount == expected
 
         cursor.execute(Q_HAS_PRIVILEGE.format(NEW_USER, 'pg_catalog.pg_class'))


### PR DESCRIPTION
**TLDR; Add tests against latest stable releases of Postgres 11, 12, & 13**

Thanks to this PR #59 for giving me a head start. However, I didn't end up integrating some of the changes in their diff. Unless I am missing something I believe it was how the test failures manifested which led them down the path of having to do the `except` ownership but I don't think this is necessary.

Although it should be restated that the tool probably does work fine on versions 11, 12, 13 and this change is more about allowing the project to prove this officially by updating the expectations in tests.

## Diff explanation

The changes in the tests were driven by two things:

* New roles in newer versions of Postgres which need to be conditionally handled depending on Postgres version under test.
* Since version 11, when creating the Postgres cluster using the official Docker image the standard `postgres` superuser is not created. There were some assumptions made in tests that reasonably expected this user to be there which need to be conditionally handled depending on the version under test.

Concretely the differences can be seen by generating a spec from freshly initialized Postgres clusters. This uses parts of the Makefile already in the repository.

```bash
make create_network

for version in 10.4 11.11 12.6 13.2
do
  export POSTGRES_VERSION="$version"
  make start_postgres
  make wait_for_postgres
  docker run -it \
    --net pgbedrock_network \
    quay.io/squarespace/pgbedrock generate \
    -h pgbedrock_postgres \
    -p 5432 \
    -d test_db \
    -U test_user \
    -w test_password | tee "/tmp/postgres-$version.yml"
done

make stop_postgres remove_network
```

I will put the contents of each version here but the main difference is between 10.4 and 11.11. **It appears that since version 11 the `postgres` superuser isn't created when given an alternative user through the `POSTGRES_USER` environment variable.** As a consequence of this the user provided owns all the items which the `postgres` superuser would have before.

In addition to these changes, you can see that version 11 also introduces some new roles not existing in older versions.


<details open>
  <summary>postgres-10.4.yml</summary>
  
```yml
# postgres-10.4.yml
pg_monitor:
    member_of:
        - pg_read_all_settings
        - pg_read_all_stats
        - pg_stat_scan_tables

pg_read_all_settings:

pg_read_all_stats:

pg_stat_scan_tables:

postgres:
    attributes:
        - BYPASSRLS
        - CREATEDB
        - CREATEROLE
        - REPLICATION
    can_login: true
    is_superuser: true
    owns:
        schemas:
            - information_schema
            - pg_catalog
            - public
        tables:
            - information_schema.*
            - pg_catalog.*
    privileges:
        schemas:
            write:
                - information_schema
                - pg_catalog
                - public

test_user:
    attributes:
        - PASSWORD "{{ env['TEST_USER_PASSWORD'] }}"
    can_login: true
    is_superuser: true
```
</details>

<details open>
  <summary>postgres-11.11.yml</summary>
  
```yml
# postgres-11.11.yml
pg_execute_server_program:

pg_monitor:
    member_of:
        - pg_read_all_settings
        - pg_read_all_stats
        - pg_stat_scan_tables

pg_read_all_settings:

pg_read_all_stats:

pg_read_server_files:

pg_stat_scan_tables:

pg_write_server_files:

test_user:
    attributes:
        - BYPASSRLS
        - CREATEDB
        - CREATEROLE
        - PASSWORD "{{ env['TEST_USER_PASSWORD'] }}"
        - REPLICATION
    can_login: true
    is_superuser: true
    owns:
        schemas:
            - information_schema
            - pg_catalog
            - public
        tables:
            - information_schema.*
            - pg_catalog.*
    privileges:
        schemas:
            write:
                - information_schema
                - pg_catalog
                - public
```
</details>

<details>
  <summary>postgres-12.6.yml</summary>
  
```yml
# postgres-12.6.yml
pg_execute_server_program:

pg_monitor:
    member_of:
        - pg_read_all_settings
        - pg_read_all_stats
        - pg_stat_scan_tables

pg_read_all_settings:

pg_read_all_stats:

pg_read_server_files:

pg_stat_scan_tables:

pg_write_server_files:

test_user:
    attributes:
        - BYPASSRLS
        - CREATEDB
        - CREATEROLE
        - PASSWORD "{{ env['TEST_USER_PASSWORD'] }}"
        - REPLICATION
    can_login: true
    is_superuser: true
    owns:
        schemas:
            - information_schema
            - pg_catalog
            - public
        tables:
            - information_schema.*
            - pg_catalog.*
    privileges:
        schemas:
            write:
                - information_schema
                - pg_catalog
                - public
```
</details>

<details>
  <summary>postgres-13.2.yml</summary>
  
```yml
# postgres-13.2.yml
pg_execute_server_program:

pg_monitor:
    member_of:
        - pg_read_all_settings
        - pg_read_all_stats
        - pg_stat_scan_tables

pg_read_all_settings:

pg_read_all_stats:

pg_read_server_files:

pg_stat_scan_tables:

pg_write_server_files:

test_user:
    attributes:
        - BYPASSRLS
        - CREATEDB
        - CREATEROLE
        - PASSWORD "{{ env['TEST_USER_PASSWORD'] }}"
        - REPLICATION
    can_login: true
    is_superuser: true
    owns:
        schemas:
            - information_schema
            - pg_catalog
            - public
        tables:
            - information_schema.*
            - pg_catalog.*
    privileges:
        schemas:
            write:
                - information_schema
                - pg_catalog
                - public
```
</details>

## Summary

The changes I have made here a very brute force attempt at getting everything working here so maybe there is a more elegant way to address these changes. For now, all the commits are marked WIP and I intend to tidy them up, squash them, update the docs, and add more code comments if the maintainers of the repository are interested in having this submission. It's just at this juncture I am unsure about the maintainer status of the project and so I don't want to sink too much time in unless there is a chance of getting things merged.

A general sidenote just to say that I love the idea of this project and it would be great to use if I can address some of the other issues (#3, #49, #17) which I am fairly motivated to do. Once again, many thanks. :)