### PR TITLE
Recognize partitioned tables as objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project tries to adhere to [Semantic Versioning](http://semver.org/spec
 ## [Unreleased]
 _this space intentionally left blank_
 
+## [0.4.3] - 2022-09-01
+
+### In Code
+- fix Q_GET_ALL_RAW_OBJECT_ATTRIBUTES in context.py to also recognize partitioned tables (@FlipEnergy)
+
 ## [0.4.2] - 2019-12-13
 ### In Code
 - Fixes for new "except" feature introduced in 0.4.0 ( @jholbrook-sqsp )

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,4 +1,5 @@
 Conrad Dean
+Dennis Zhang
 John Shiver
 Michael Dudley
 Zach Marine

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,7 @@ test27:
         --rm \
         -e WITHIN_DOCKER_FLAG=true \
         -e POSTGRES_PORT=5432 \
+        -e POSTGRES_VERSION=$(POSTGRES_VERSION) \
         -v $(shell pwd):/opt \
         --net=$(COMPOSED_NETWORK) \
         tester27
@@ -118,6 +119,7 @@ test36:
         --rm \
         -e WITHIN_DOCKER_FLAG=true \
         -e POSTGRES_PORT=5432 \
+        -e POSTGRES_VERSION=$(POSTGRES_VERSION) \
         -v $(shell pwd):/opt \
         --net=$(COMPOSED_NETWORK) \
         tester36

--- a/pgbedrock/__init__.py
+++ b/pgbedrock/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.4.2'
+__version__ = '0.4.3'
 LOG_FORMAT = '%(levelname)s:%(filename)s:%(funcName)s:%(lineno)s - %(message)s'

--- a/pgbedrock/context.py
+++ b/pgbedrock/context.py
@@ -143,6 +143,7 @@ Q_GET_ALL_RAW_OBJECT_ATTRIBUTES = """
                ('v', 'tables'),
                ('m', 'tables'),
                ('f', 'tables'),
+               ('p', 'tables'),
                ('S', 'sequences')
     ), tables_and_sequences AS (
         SELECT

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ pytest==3.1.3
 pytest-cov==2.5.1
 -r requirements-docs.txt
 wheel==0.33.6
+psycopg2==2.7.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Cerberus==1.1
 click==6.7
 Jinja2==2.10.1
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 psycopg2==2.7.3
 PyYAML==5.2


### PR DESCRIPTION
I don't expect this to be merged but throwing this PR up for other folks who may find use in it.

* support for partitioned tables

* pin dev psycopg2==2.7.7 to still pass all tests

* add partitioned test

* changelog and version bump

* pin working MarkupSafe==1.1.1